### PR TITLE
[AWS-RDS] RDS migration

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,7 +1,7 @@
 # MySQL
-spring.datasource.url=jdbc:mysql://52.78.18.217:3306/taskforce
+spring.datasource.url=jdbc:mysql://taskforce-rds.ck33ctw42qr1.ap-northeast-2.rds.amazonaws.com:3306/taskforce
 spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
-spring.datasource.username=root
+spring.datasource.username=admin
 spring.datasource.password=taskforce
 
 #JPA

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,7 +1,7 @@
 # MySQL
-spring.datasource.url=jdbc:mysql://52.78.18.217:3306/taskforce
+spring.datasource.url=jdbc:mysql://taskforce-rds.ck33ctw42qr1.ap-northeast-2.rds.amazonaws.com:3306/taskforce
 spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
-spring.datasource.username=root
+spring.datasource.username=admin
 spring.datasource.password=taskforce
 
 #JPA

--- a/test-infra/infra/docker-compose.yml
+++ b/test-infra/infra/docker-compose.yml
@@ -1,22 +1,5 @@
 version: '3'
 services:
-  database:
-    container_name: super-mysql
-    image: mysql:8
-    ports:
-      - '3306:3306'
-    volumes:
-      - ./db/conf:/etc/mysql/conf.d
-      - ./db/volume:/var/lib/mysql
-    environment:
-      MYSQL_DATABASE: taskforce
-      MYSQL_ROOT_PASSWORD: taskforce
-      TZ: Asia/Seoul
-    command:
-      - --character-set-server=utf8mb4
-      - --collation-server=utf8mb4_unicode_ci
-      - --default-authentication-plugin=mysql_native_password
-
   cache:
     container_name: super-redis
     image: redis
@@ -24,3 +7,23 @@ services:
       - ./redis/volume:/data
     ports:
       - '6379:6379'
+
+#  RDS - migration 으로 미사용
+#  database:
+#    container_name: super-mysql
+#    image: mysql:8
+#    ports:
+#      - '3306:3306'
+#    volumes:
+#      - ./db/conf:/etc/mysql/conf.d
+#      - ./db/volume:/var/lib/mysql
+#      - ./db/backup:/backup
+#    environment:
+#      MYSQL_DATABASE: taskforce
+#      MYSQL_ROOT_PASSWORD: taskforce
+#      TZ: Asia/Seoul
+#    command:
+#      - --character-set-server=utf8mb4
+#      - --collation-server=utf8mb4_unicode_ci
+#      - --default-authentication-plugin=mysql_native_password
+


### PR DESCRIPTION
불쌍한 EC2 프리티어를 구제하기위해 

기존 ec2에 있는 mysql을 rds로 이관

https://github.com/TASK-FORCE/super-docs/issues/7#issue-679685437