### PR TITLE
카카오 유저 프로필 사진이 없을 때 발생하는 에러 개선

### DIFF
--- a/src/main/kotlin/com/taskforce/superinvention/app/web/dto/kakao/kakaoDto.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/dto/kakao/kakaoDto.kt
@@ -40,14 +40,14 @@ class KakaoUserRegistRequest (
 
 class KakaoUserProperties (
         val nickname: String,
-        val profile_image: String,
-        val thumbnail_image: String
+        val profile_image: String = "",
+        val thumbnail_image: String = ""
 )
 
 class KakaoUserProfile(
         val nickname: String,
-        val thumbnail_image_url: String,
-        val profile_image_url: String
+        val profile_image_url: String = "",
+        val thumbnail_image_url: String = ""
 )
 
 class KakaoUserAccount (


### PR DESCRIPTION
#41 카카오 유저 정보 조회시 프로필 사진이 없으면 NPE가 발생함. 그렇기 때문에 NPE 방지 코드를 삽입