### PR TITLE
[CI/CD] 빌드 / 배포 분리

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: [Build] Super-Invention
+
+on:
+  push:
+    branches: [ develop ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+      
+    - name: Build with Gradle
+      run: ./gradlew build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,6 @@
-name: Deploy Super-Invention Server
+name: [Deploy] Super-Invention
 
-on:
-  push:
-    branches: [ develop ]
+on: workflow_dispatch
 
 jobs:
   build:


### PR DESCRIPTION
https://docs.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts

원래 위에 꺼로 빌드 하고 빌드된 파일을 따로 저장해서 배포는 빌드 안하고 바로하게 할랬는데 복잡하네요 ㅋㅋ
일단 빌드 따로 배포 (빌드+배포) 따로 올립니다
