### PR TITLE
모임 검색기능 추가

### DIFF
--- a/src/docs/asciidoc/club/addClubUser.adoc
+++ b/src/docs/asciidoc/club/addClubUser.adoc
@@ -10,30 +10,23 @@ endif::[]
 :site-url: /build/asciidoc/html5/state
 
 === Request
-==== [Request HTTP]
 include::{sub-snippet}/addClub/http-request.adoc[]
 
-=== [Request Fields]
 ....
 Request Fields 없음
 ....
 
-==== [curl example]
 include::{sub-snippet}/addClub/curl-request.adoc[]
 
-==== [Request Body]
 ....
 Request Body 없음
 ....
 
 === Response
-==== [Response Fields]
 ....
 Response Fields 없음
 ....
 
-==== [Response HTTP Example]
 include::{sub-snippet}/addClub/http-response.adoc[]
 
-==== [Response body]
 include::{sub-snippet}/addClub/response-body.adoc[]

--- a/src/docs/asciidoc/club/searchClub.adoc
+++ b/src/docs/asciidoc/club/searchClub.adoc
@@ -1,0 +1,26 @@
+ifndef::snippets[]
+:sub-snippet: ../../../../build/generated-snippets
+endif::[]
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:sectlinks:
+:site-url: /build/asciidoc/html5/state
+
+=== Request
+include::{sub-snippet}/searchClub/http-request.adoc[]
+
+include::{sub-snippet}/searchClub/request-fields.adoc[]
+
+include::{sub-snippet}/searchClub/curl-request.adoc[]
+
+include::{sub-snippet}/searchClub/request-body.adoc[]
+
+=== Response
+include::{sub-snippet}/searchClub/http-response.adoc[]
+
+include::{sub-snippet}/searchClub/response-fields.adoc[]
+
+include::{sub-snippet}/searchClub/response-body.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -55,3 +55,6 @@ include::{root}/club/addClub.adoc[]
 
 == 모임 가입
 include::{root}/club/addClubUser.adoc[]
+
+== 모임 검색
+include::{root}/club/searchClub.adoc[]

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/Club.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/Club.kt
@@ -7,7 +7,8 @@ import javax.persistence.Entity
 class Club(
     var name: String,
     var description: String,
-    var maximumNumber: Long
+    var maximumNumber: Long,
+    var mainImageUrl: String?
 ) : BaseEntity() {
 
 }

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/ClubRepositorySupport.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/ClubRepositorySupport.kt
@@ -1,20 +1,64 @@
 package com.taskforce.superinvention.app.domain.club
 
-import com.querydsl.jpa.JPQLQuery
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.taskforce.superinvention.app.domain.club.QClub.club
+import com.taskforce.superinvention.app.domain.club.QClubUser.clubUser
+import com.taskforce.superinvention.app.domain.interest.QClubInterest.clubInterest
+import com.taskforce.superinvention.app.web.dto.club.ClubSearchOptions
+import com.taskforce.superinvention.app.web.dto.interest.InterestRequestDto
+import com.taskforce.superinvention.app.web.dto.state.StateRequestDto
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
 import org.springframework.stereotype.Repository
+import org.springframework.util.ObjectUtils
 
 @Repository
-class ClubRepositorySupport : QuerydslRepositorySupport(Club::class.java) {
+class ClubRepositorySupport(val queryFactory:JPAQueryFactory) : QuerydslRepositorySupport(Club::class.java) {
     fun findBySeq(seq: Long): Club {
-        return from(QClub.club)
-                .where(QClub.club.seq.eq(seq))
+        return from(club)
+                .where(club.seq.eq(seq))
                 .fetchOne()
     }
 
     fun findByKeyword(keyword: String): List<Club>? {
-        return from(QClub.club)
-                .where(QClub.club.name.like(keyword))
+        return from(club)
+                .where(club.name.like(keyword))
                 .fetch()
+    }
+
+    fun search(clubSearchOptions: ClubSearchOptions, pageable:Pageable): Page<Club> {
+        val fetchResult = queryFactory
+                .selectFrom(club)
+                .leftJoin(clubInterest.club, club)
+                .where(
+                    eqInterests(clubSearchOptions.interestList)
+                    , eqStates(clubSearchOptions.stateList)
+                )
+                .orderBy()
+                .offset(pageable.offset)
+                .limit(pageable.pageSize.toLong())
+                .fetchResults()
+        return PageImpl(fetchResult.results, pageable, fetchResult.total)
+    }
+
+    private fun eqInterests(interestList:List<InterestRequestDto>): BooleanExpression? {
+        if (ObjectUtils.isEmpty(interestList)) return null
+        return clubInterest.interest.seq.`in`(interestList.map { e -> e.seq })
+    }
+
+    private fun eqStates(stateList:List<StateRequestDto>): BooleanExpression? {
+        if (ObjectUtils.isEmpty(stateList)) return null
+        return clubInterest.interest.seq.`in`(stateList.map { e -> e.seq })
+    }
+
+    fun getUserCount(clubSeq: Long): Long {
+        return queryFactory.select(clubUser.user.count())
+                .from(club)
+                .leftJoin(clubUser.club, club)
+                .where(club.seq.eq(clubSeq))
+                .fetchCount()
     }
 }

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/ClubService.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/ClubService.kt
@@ -2,7 +2,12 @@ package com.taskforce.superinvention.app.domain.club
 
 import com.taskforce.superinvention.app.domain.role.RoleService
 import com.taskforce.superinvention.app.domain.user.user.User
+import com.taskforce.superinvention.app.web.dto.club.ClubDto
+import com.taskforce.superinvention.app.web.dto.club.ClubSearchRequestDto
 import com.taskforce.superinvention.app.web.dto.club.ClubUserDto
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.lang.RuntimeException
@@ -59,5 +64,12 @@ class ClubService(
         }
         val clubUser = ClubUser(club = club, user = user)
         clubUserRepository.save(clubUser)
+    }
+
+
+    fun search(request: ClubSearchRequestDto): List<ClubDto> {
+        val pageable:Pageable = PageRequest.of(request.offset.toInt(), request.size.toInt())
+        val result = clubRepositorySupport.search(request.searchOptions, pageable)
+        return result.map { e -> ClubDto(club = e, userCount = clubRepositorySupport.getUserCount(e.seq!!)) }.toList()
     }
 }

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/ClubController.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/ClubController.kt
@@ -3,22 +3,25 @@ package com.taskforce.superinvention.app.web
 import com.taskforce.superinvention.app.domain.club.Club
 import com.taskforce.superinvention.app.domain.club.ClubService
 import com.taskforce.superinvention.app.domain.user.user.User
+import com.taskforce.superinvention.app.domain.user.userInterest.UserInterestService
+import com.taskforce.superinvention.app.domain.user.userState.UserStateService
 import com.taskforce.superinvention.app.web.dto.club.ClubAddRequestDto
+import com.taskforce.superinvention.app.web.dto.club.ClubDto
+import com.taskforce.superinvention.app.web.dto.club.ClubSearchRequestDto
 import com.taskforce.superinvention.app.web.dto.club.ClubUserDto
+import com.taskforce.superinvention.app.web.dto.state.StateRequestDto
 import com.taskforce.superinvention.common.config.argument.auth.AuthUser
 import org.springframework.security.access.annotation.Secured
+import org.springframework.util.ObjectUtils
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("clubs")
 class ClubController(
-        val clubService : ClubService
+        val clubService : ClubService,
+        val userStateService: UserStateService,
+        val userInterestService: UserInterestService
 ) {
-    @GetMapping
-    fun retrieveClubs(@RequestParam("keyword") keyword : String): List<Club>?{
-        return clubService.retrieveClubs(keyword)
-    }
-
     @GetMapping("/{seq}")
     fun getClubBySeq(@PathVariable seq : Long): Club? {
         return clubService.getClubBySeq(seq)
@@ -39,7 +42,26 @@ class ClubController(
     @Secured("ROLE_USER")
     @PostMapping
     fun addClub(@AuthUser user: User, @RequestBody request: ClubAddRequestDto) {
-        val club = Club(name = request.name, description = request.description, maximumNumber = request.maximumNumber)
+        val club = Club(name = request.name, description = request.description, maximumNumber = request.maximumNumber, mainImageUrl = request.mainImageUrl)
         clubService.addClub(club, user)
+    }
+
+    /**
+     * 모임리스트 검색
+     * @author eric
+     */
+    @GetMapping
+    fun getClubList(@AuthUser user: User, @RequestBody request: ClubSearchRequestDto): List<ClubDto> {
+        if (ObjectUtils.isEmpty(request.searchOptions.stateList)) {
+            val userStateDto = userStateService.findUserStateList(user)
+            request.searchOptions.stateList = userStateDto.userStates.map { e -> StateRequestDto(e.stateDto.seq, e.priority) }.toList()
+        }
+
+        if (ObjectUtils.isEmpty(request.searchOptions.interestList)) {
+            // TODO: UserInterest 조회 메서드 생성이 끝나면 여기 완성하자
+            // val userInterestDto = userInterestService.findUserInterestList(user);
+        }
+
+        return clubService.search(request)
     }
 }

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/dto/club/ClubAddRequestDto.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/dto/club/ClubAddRequestDto.kt
@@ -3,6 +3,7 @@ package com.taskforce.superinvention.app.web.dto.club
 class ClubAddRequestDto(
         var name: String,
         var description: String,
-        var maximumNumber: Long
+        var maximumNumber: Long,
+        var mainImageUrl: String?
 ) {
 }

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/dto/club/ClubDto.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/dto/club/ClubDto.kt
@@ -7,7 +7,8 @@ class ClubDto (
         var name: String,
         var description: String,
         var maximumNumber: Long,
-        var userCount: Long
+        var userCount: Long,
+        var mainImageUrl: String?
 ){
-    constructor(club : Club, userCount: Long): this(club.seq, club.name, club.description, club.maximumNumber, userCount)
+    constructor(club : Club, userCount: Long): this(club.seq, club.name, club.description, club.maximumNumber, userCount, club.mainImageUrl)
 }

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/dto/club/ClubSearchRequestDto.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/dto/club/ClubSearchRequestDto.kt
@@ -1,0 +1,15 @@
+package com.taskforce.superinvention.app.web.dto.club
+
+import com.taskforce.superinvention.app.web.dto.interest.InterestRequestDto
+import com.taskforce.superinvention.app.web.dto.state.StateRequestDto
+
+class ClubSearchRequestDto(
+        val offset:Long = 0,
+        val size:Long = 10,
+        val searchOptions: ClubSearchOptions
+)
+
+class ClubSearchOptions(
+    var stateList: List<StateRequestDto>,
+    var interestList: List<InterestRequestDto>
+)

--- a/src/test/kotlin/com/taskforce/superinvention/config/ApiDocumentationTest.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/config/ApiDocumentationTest.kt
@@ -8,6 +8,7 @@ import com.taskforce.superinvention.app.domain.state.StateService
 import com.taskforce.superinvention.app.domain.user.user.UserDetailsProvider
 import com.taskforce.superinvention.app.domain.user.user.UserRepository
 import com.taskforce.superinvention.app.domain.user.user.UserService
+import com.taskforce.superinvention.app.domain.user.userInterest.UserInterestService
 import com.taskforce.superinvention.app.domain.user.userState.UserStateService
 import com.taskforce.superinvention.app.web.ClubController
 import com.taskforce.superinvention.app.web.InterestGroupController
@@ -64,4 +65,7 @@ abstract class ApiDocumentationTest {
 
     @MockBean
     lateinit var clubService: ClubService
+
+    @MockBean
+    lateinit var userInterestService: UserInterestService
 }

--- a/src/test/kotlin/com/taskforce/superinvention/document/club/ClubDocumentation.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/document/club/ClubDocumentation.kt
@@ -1,18 +1,21 @@
 package com.taskforce.superinvention.document.club
 
 import com.taskforce.superinvention.app.domain.club.Club
-import com.taskforce.superinvention.app.domain.interest.interest.InterestDto
-import com.taskforce.superinvention.app.domain.interest.interestGroup.InterestGroupDto
 import com.taskforce.superinvention.app.web.dto.club.ClubAddRequestDto
+import com.taskforce.superinvention.app.web.dto.club.ClubDto
+import com.taskforce.superinvention.app.web.dto.club.ClubSearchOptions
+import com.taskforce.superinvention.app.web.dto.club.ClubSearchRequestDto
+import com.taskforce.superinvention.app.web.dto.interest.InterestRequestDto
+import com.taskforce.superinvention.app.web.dto.state.StateRequestDto
 import com.taskforce.superinvention.config.ApiDocumentUtil.getDocumentRequest
 import com.taskforce.superinvention.config.ApiDocumentUtil.getDocumentResponse
 import com.taskforce.superinvention.config.ApiDocumentationTest
 import com.taskforce.superinvention.config.MockitoHelper
 import org.junit.jupiter.api.Test
-import org.mockito.BDDMockito.given
 import org.mockito.Mockito.`when`
 import org.springframework.http.MediaType
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post
 import org.springframework.restdocs.payload.JsonFieldType
 import org.springframework.restdocs.payload.PayloadDocumentation.*
@@ -26,7 +29,7 @@ class ClubDocumentation: ApiDocumentationTest() {
     @WithMockUser
     fun `모임 생성`() {
         val clubAddRequestDto = ClubAddRequestDto(
-                name = "땔감 스터디", description = "땔깜중에서도 고오급 땔깜이 되기 위해 노력하는 스터디", maximumNumber = 5L)
+                name = "땔감 스터디", description = "땔깜중에서도 고오급 땔깜이 되기 위해 노력하는 스터디", maximumNumber = 5L, mainImageUrl = "s3urlhost/d2e4dxxadf2E.png")
 
         val result = mockMvc.perform(
                 post("/clubs")
@@ -43,7 +46,8 @@ class ClubDocumentation: ApiDocumentationTest() {
                                 requestFields(
                                         fieldWithPath("name").type(JsonFieldType.STRING).description("모임명"),
                                         fieldWithPath("description").type(JsonFieldType.STRING).description("모임 설명"),
-                                        fieldWithPath("maximumNumber").type(JsonFieldType.NUMBER).description("모임 최대 인원 수(변경 가능)")
+                                        fieldWithPath("maximumNumber").type(JsonFieldType.NUMBER).description("모임 최대 인원 수(변경 가능)"),
+                                        fieldWithPath("mainImageUrl").type(JsonFieldType.STRING).description("모임 메인 이미지 url (Nullable)")
                                 )
                         )
                 )
@@ -57,7 +61,8 @@ class ClubDocumentation: ApiDocumentationTest() {
                 .thenReturn(Club(
                         "가상 모임",
                         "가상 모임에 대한 설명",
-                        100L
+                        100L,
+                        null
                 ))
 
         val result = mockMvc.perform(
@@ -71,6 +76,93 @@ class ClubDocumentation: ApiDocumentationTest() {
         result.andExpect(status().isOk)
                 .andDo(
                         document("addClubUser", getDocumentRequest(), getDocumentResponse())
+                )
+    }
+
+    @Test
+    @WithMockUser
+    fun `모임 리스트 조회`() {
+        // given
+        val searchResult = listOf(
+                ClubDto(
+                        seq = 6023L,
+                        name = "산타 아저씨들",
+                        description = "산이 너무 좋은 사람들의 모임입니다. 매주 정모 필참! 정모 후 뒷풀이는 선택." +
+                                "많이 가입해주세요~",
+                        maximumNumber = 300L,
+                        userCount = 42L,
+                        mainImageUrl = "taskforce-file-server/Exv2Es.png"
+                ),
+                ClubDto(
+                        seq = 45128989L,
+                        name = "헬린이에서 근돼까지",
+                        description = "와우 친구들 헬스장 아저씨야. " +
+                                "3대 500 이상 착용할 수 있는 언더아머를 착용할 수 있을때 까지 힘내보자구!",
+                        maximumNumber = 50L,
+                        userCount = 1L,
+                        mainImageUrl = "taskforce-file-server/0xV12v2Es.png"
+                )
+        )
+
+        val searchRequest = ClubSearchRequestDto(
+                offset = 0L,
+                size = 10L,
+                searchOptions = ClubSearchOptions(
+                        stateList = listOf(
+                                StateRequestDto(
+                                        seq = 102L,
+                                        priority = 1L
+                                )
+                        ),
+                        interestList = listOf(
+                            InterestRequestDto(
+                                    seq = 4L,
+                                    priority = 1L
+                            ),
+                            InterestRequestDto(
+                                    seq = 20L,
+                                    priority = 2L
+                            )
+                        )
+                )
+        )
+
+        `when`(clubService.search(MockitoHelper.anyObject())).thenReturn(searchResult)
+
+        // when
+        val result = mockMvc.perform(
+                get("/clubs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdXRoIjoiW1VTRVJdIi")
+                        .characterEncoding("UTF-8")
+                        .content(objectMapper.writeValueAsString(searchRequest))
+        ).andDo(print())
+
+        // then
+        result.andExpect(status().isOk)
+                .andDo(
+                        document("searchClub", getDocumentRequest(), getDocumentResponse(),
+                                requestFields(
+                                        fieldWithPath("offset").type(JsonFieldType.NUMBER).description("요청하는 페이지"),
+                                        fieldWithPath("size").type(JsonFieldType.NUMBER).description("한번에 조회할 모임 개수"),
+                                        fieldWithPath("searchOptions").type(JsonFieldType.OBJECT).description("검색할 조건들(현재는 지역, 관심사를 검색 조건에 넣을 수 있음)"),
+                                        fieldWithPath("searchOptions.stateList").type(JsonFieldType.ARRAY).description("검색할 지역 리스트 (비어있어도 된다)"),
+                                        fieldWithPath("searchOptions.stateList[].seq").type(JsonFieldType.NUMBER).description("지역 시퀀스"),
+                                        fieldWithPath("searchOptions.stateList[].priority").type(JsonFieldType.NUMBER).description("검색할 지역의 우선순위. 높을수록 해당 지역의 우선순위를 높게 설정하여 상단에 노출된다."),
+                                        fieldWithPath("searchOptions.interestList[]").type(JsonFieldType.ARRAY).description("검색할 관심사 리스트 (비어있어도 된다)"),
+                                        fieldWithPath("searchOptions.interestList[].seq").type(JsonFieldType.NUMBER).description("관심사 시퀀스"),
+                                        fieldWithPath("searchOptions.interestList[].priority").type(JsonFieldType.NUMBER).description("검색할 관심사의 우선순위. 높을수록 해당 관심사의 우선순위를 높게 설정하여 상단에 노출된다.")
+                                ),
+                                responseFields(
+                                        fieldWithPath("[].seq").type(JsonFieldType.NUMBER).description("모임의 시퀀스"),
+                                        fieldWithPath("[].name").type(JsonFieldType.STRING).description("모임명"),
+                                        fieldWithPath("[].description").type(JsonFieldType.STRING).description("모임에 대한 설명"),
+                                        fieldWithPath("[].maximumNumber").type(JsonFieldType.NUMBER).description("모임 최대 가입 인원수"),
+                                        fieldWithPath("[].userCount").type(JsonFieldType.NUMBER).description("현재 모임원 인원수"),
+                                        fieldWithPath("[].mainImageUrl").type(JsonFieldType.STRING).description("모임 메인 이미지 (Nullable)")
+                                )
+                        )
                 )
     }
 }


### PR DESCRIPTION
#62 모임 검색
- 원하는 지역을 선택하여 검색 가능
- 원하는 관심사를 선택하여 검색이 가능하도록 추가할 예정

1단계, 선택한 관심사를 기준으로 모임 조회
2단계, 지역 내부 모임중 관심사가 일치하는 모임 조회

검색조건을 넣지 않는다면, 유저가 미리 선택해놓은 지역과 관심사를 우선적으로 선택한다.