### PR TITLE
모임 검색시 GET 요청 => POST 요청으로 변경

### DIFF
--- a/src/main/kotlin/com/taskforce/superinvention/app/web/ClubController.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/ClubController.kt
@@ -52,7 +52,7 @@ class ClubController(
      * 모임리스트 검색
      * @author eric
      */
-    @GetMapping
+    @PostMapping("/search")
     fun getClubList(@AuthUser user: User, @RequestBody request: ClubSearchRequestDto): List<ClubWithStateInterestDto> {
         if (ObjectUtils.isEmpty(request.searchOptions.stateList)) {
             val userStateDto = userStateService.findUserStateList(user)

--- a/src/test/kotlin/com/taskforce/superinvention/document/club/ClubDocumentation.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/document/club/ClubDocumentation.kt
@@ -170,7 +170,7 @@ class ClubDocumentation: ApiDocumentationTest() {
 
         // when
         val result = mockMvc.perform(
-                get("/clubs")
+                post("/clubs/search")
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdXRoIjoiW1VTRVJdIi")


### PR DESCRIPTION
#84 Axios 내부적으로 HTTP GET 요청에는 Body를 담을 수 없게 되어있어서, 부득이하게 검색을 POST 요청으로 보내도록 한다