### PR TITLE
모임조회시 관심사가 높은 순서대로 조회되도록 수정

### DIFF
--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/Club.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/Club.kt
@@ -5,10 +5,7 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators
 import com.taskforce.superinvention.app.domain.BaseEntity
 import com.taskforce.superinvention.app.domain.interest.ClubInterest
 import com.taskforce.superinvention.app.domain.state.ClubState
-import javax.persistence.Entity
-import javax.persistence.FetchType
-import javax.persistence.JoinColumn
-import javax.persistence.OneToMany
+import javax.persistence.*
 
 @Entity
 @JsonIdentityInfo(property = "seq", generator = ObjectIdGenerators.StringIdGenerator::class)
@@ -20,10 +17,12 @@ class Club(
 ) : BaseEntity() {
     @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "club_seq")
+    @OrderBy("priority")
     lateinit var clubInterests: List<ClubInterest>
 
     @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "club_seq")
+    @OrderBy("priority")
     lateinit var clubStates: List<ClubState>
 
     @OneToMany(fetch = FetchType.LAZY)


### PR DESCRIPTION
`@OrderBy` 어노테이션으로 디폴트로 `priority`를 기준으로 정렬하도록 만듦