### PR TITLE
내 모임 조회 HTTP메서드를 POST로 변경

### DIFF
--- a/src/main/kotlin/com/taskforce/superinvention/app/web/ClubController.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/ClubController.kt
@@ -155,7 +155,7 @@ class ClubController(
         return ResponseDto(data = roles.map { role -> RoleDto(role) }.toSet())
     }
 
-    @GetMapping("/my")
+    @PostMapping("/my")
     @Secured(Role.MEMBER)
     fun getMyClubList(@AuthUser user: User, @RequestBody searchOptions: PageOption): ResponseDto<Page<ClubUserDto>> {
         return ResponseDto(data = clubService.getUserClubList(user, searchOptions))

--- a/src/test/kotlin/com/taskforce/superinvention/document/club/ClubDocumentation.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/document/club/ClubDocumentation.kt
@@ -535,7 +535,7 @@ class ClubDocumentation: ApiDocumentationTest() {
         val requestBody = PageOption()
 
         val result = mockMvc.perform(
-                get("/clubs/my")
+                post("/clubs/my")
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdXRoIjoiW1VTRVJdIi")


### PR DESCRIPTION
#113 
Axios가 GET 메서드에 Body를 지원하지 않는 관계로
내 모임 조회기능을 GET이 아닌 POST로 검색하도록 변경