### PR TITLE
모임 검색시 모임의 관심사 그룹 정보를 함께 반환할 수 있도록 정보 추가

### DIFF
--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/interest/ClubInterest.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/interest/ClubInterest.kt
@@ -3,6 +3,7 @@ package com.taskforce.superinvention.app.domain.interest
 import com.taskforce.superinvention.app.domain.BaseEntity
 import com.taskforce.superinvention.app.domain.club.Club
 import com.taskforce.superinvention.app.domain.interest.interest.Interest
+import com.taskforce.superinvention.app.domain.interest.interestGroup.InterestGroup
 import javax.persistence.Entity
 import javax.persistence.FetchType
 import javax.persistence.ManyToOne

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/interest/interest/InterestDto.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/interest/interest/InterestDto.kt
@@ -1,18 +1,21 @@
 package com.taskforce.superinvention.app.domain.interest.interest
 
-import com.taskforce.superinvention.app.domain.interest.ClubInterest
+import com.taskforce.superinvention.app.domain.interest.interestGroup.SimpleInterestGroupDto
 
 class InterestDto {
     var seq: Long?
     var name: String
+    var interestGroup: SimpleInterestGroupDto
 
-    constructor(seq: Long?, name: String) {
+    constructor(seq: Long?, name: String, interestGroup: SimpleInterestGroupDto) {
         this.seq  = seq
         this.name = name
+        this.interestGroup = interestGroup
     }
 
     constructor(interest: Interest) {
         this.seq = interest.seq
         this.name = interest.name
+        this.interestGroup = SimpleInterestGroupDto(interest.interestGroup)
     }
 }

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/interest/interestGroup/InterestGroupDto.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/interest/interestGroup/InterestGroupDto.kt
@@ -11,7 +11,7 @@ class InterestGroupDto {
     constructor(group: InterestGroup, interestList: List<Interest> ) {
         this.name = group.name
         this.groupSeq = group.seq
-        this.interestList = interestList.map { interest -> InterestDto(interest.seq, interest.name)}.toMutableList()
+        this.interestList = interestList.map { interest -> InterestDto(interest.seq, interest.name, SimpleInterestGroupDto(interest.interestGroup))}.toMutableList()
     }
 
     constructor(groupSeq: Long, name: String, interestList: List<InterestDto> ) {
@@ -19,5 +19,12 @@ class InterestGroupDto {
         this.groupSeq = groupSeq
         this.interestList = interestList
     }
+}
+
+class SimpleInterestGroupDto(
+        val seq: Long,
+        val name: String
+) {
+    constructor(interestGroup:InterestGroup): this(interestGroup.seq!!, interestGroup.name)
 }
 

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/dto/interest/InterestWithPriorityDto.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/dto/interest/InterestWithPriorityDto.kt
@@ -1,6 +1,5 @@
 package com.taskforce.superinvention.app.web.dto.interest
 
-import com.taskforce.superinvention.app.domain.club.Club
 import com.taskforce.superinvention.app.domain.interest.ClubInterest
 import com.taskforce.superinvention.app.domain.interest.interest.InterestDto
 

--- a/src/test/kotlin/com/taskforce/superinvention/document/club/ClubDocumentation.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/document/club/ClubDocumentation.kt
@@ -6,6 +6,7 @@ import com.taskforce.superinvention.app.domain.interest.ClubInterest
 import com.taskforce.superinvention.app.domain.interest.interest.Interest
 import com.taskforce.superinvention.app.domain.interest.interest.InterestDto
 import com.taskforce.superinvention.app.domain.interest.interestGroup.InterestGroup
+import com.taskforce.superinvention.app.domain.interest.interestGroup.SimpleInterestGroupDto
 import com.taskforce.superinvention.app.domain.region.ClubRegion
 import com.taskforce.superinvention.app.domain.region.Region
 import com.taskforce.superinvention.app.domain.role.Role
@@ -140,8 +141,8 @@ class ClubDocumentation: ApiDocumentationTest() {
                         userCount = 42L,
                         mainImageUrl = "taskforce-file-server/Exv2Es.png",
                         interests = listOf(
-                                InterestWithPriorityDto(InterestDto(seq = 1, name = "운동"), 1),
-                                InterestWithPriorityDto(InterestDto(seq = 2, name = "건강"), 2)
+                                InterestWithPriorityDto(InterestDto(seq = 1, name = "운동", interestGroup = SimpleInterestGroupDto(1L, "운동/스포츠")), 1),
+                                InterestWithPriorityDto(InterestDto(seq = 2, name = "건강", interestGroup = SimpleInterestGroupDto(1L, "운동/스포츠")), 2)
                         ),
                         regions = listOf(
                                 RegionWithPriorityDto(SimpleRegionDto(seq = 101, name = "강남구", superRegionRoot = "서울특별시/강남구", level = 2), 1),
@@ -157,8 +158,8 @@ class ClubDocumentation: ApiDocumentationTest() {
                         userCount = 1L,
                         mainImageUrl = "taskforce-file-server/0xV12v2Es.png",
                         interests = listOf(
-                                InterestWithPriorityDto(InterestDto(seq = 1, name = "운동"), 1),
-                                InterestWithPriorityDto(InterestDto(seq = 2, name = "건강"), 2)
+                                InterestWithPriorityDto(InterestDto(seq = 1, name = "운동", interestGroup = SimpleInterestGroupDto(1L, "운동/스포츠")), 1),
+                                InterestWithPriorityDto(InterestDto(seq = 2, name = "건강", interestGroup = SimpleInterestGroupDto(1L, "운동/스포츠")), 2)
                         ),
                         regions = listOf(
                                 RegionWithPriorityDto(SimpleRegionDto(seq = 101, name = "강남구", superRegionRoot = "서울특별시/강남구", level = 2), 1),
@@ -231,6 +232,9 @@ class ClubDocumentation: ApiDocumentationTest() {
                                         fieldWithPath("data.content[].interests[].interest").type(JsonFieldType.OBJECT).description("모임 관심사 정보"),
                                         fieldWithPath("data.content[].interests[].interest.seq").type(JsonFieldType.NUMBER).description("모임 관심사 시퀀스"),
                                         fieldWithPath("data.content[].interests[].interest.name").type(JsonFieldType.STRING).description("모임 관심사 이름"),
+                                        fieldWithPath("data.content[].interests[].interest.interestGroup").type(JsonFieldType.OBJECT).description("관심사 그룹 정보"),
+                                        fieldWithPath("data.content[].interests[].interest.interestGroup.seq").type(JsonFieldType.NUMBER).description("관심사 그룹 시퀀스"),
+                                        fieldWithPath("data.content[].interests[].interest.interestGroup.name").type(JsonFieldType.STRING).description("관심사 그룹 이름"),
                                         fieldWithPath("data.content[].interests[].priority").type(JsonFieldType.NUMBER).description("관심사 우선순위"),
                                         fieldWithPath("data.content[].regions").type(JsonFieldType.ARRAY).description("모임 참여지역"),
                                         fieldWithPath("data.content[].regions[].region").type(JsonFieldType.OBJECT).description("모임 지역 정보"),
@@ -265,19 +269,19 @@ class ClubDocumentation: ApiDocumentationTest() {
         )
         club.seq = clubSeq
 
+        val interestGroup = InterestGroup(
+                "건강",
+                listOf()
+        )
+        interestGroup.seq = 1
+
         val interest3 = Interest(
                 "헬스",
-                interestGroup = InterestGroup(
-                        "건강",
-                        listOf()
-                )
+                interestGroup = interestGroup
         )
         val interest5 = Interest(
                 "운동",
-                interestGroup = InterestGroup(
-                        "건강",
-                        listOf()
-                )
+                interestGroup = interestGroup
         )
 
         val clubInterest1 = ClubInterest(
@@ -365,6 +369,9 @@ class ClubDocumentation: ApiDocumentationTest() {
                             fieldWithPath("data.interests[].interest").type(JsonFieldType.OBJECT).description("모임 관심사 정보"),
                             fieldWithPath("data.interests[].interest.seq").type(JsonFieldType.NUMBER).description("모임 관심사 시퀀스"),
                             fieldWithPath("data.interests[].interest.name").type(JsonFieldType.STRING).description("모임 관심사 이름"),
+                          fieldWithPath("data.interests[].interest.interestGroup").type(JsonFieldType.OBJECT).description("관심사 그룹 정보"),
+                            fieldWithPath("data.interests[].interest.interestGroup.seq").type(JsonFieldType.NUMBER).description("관심사 그룹 시퀀스"),
+                            fieldWithPath("data.interests[].interest.interestGroup.name").type(JsonFieldType.STRING).description("관심사 그룹 이름"),
                             fieldWithPath("data.interests[].priority").type(JsonFieldType.NUMBER).description("관심사 우선순위"),
                             fieldWithPath("data.regions").type(JsonFieldType.ARRAY).description("모임 참여지역"),
                             fieldWithPath("data.regions[].region").type(JsonFieldType.OBJECT).description("모임 지역 정보"),
@@ -587,19 +594,19 @@ class ClubDocumentation: ApiDocumentationTest() {
         )
         club.seq = clubSeq
 
+        val interestGroup = InterestGroup(
+                "건강",
+                listOf()
+        )
+        interestGroup.seq = 1
+
         val interest3= Interest(
                 "헬스",
-                interestGroup = InterestGroup(
-                        "건강",
-                        listOf()
-                )
+                interestGroup = interestGroup
         )
         val interest5 = Interest(
                 "운동",
-                interestGroup = InterestGroup(
-                        "건강",
-                        listOf()
-                )
+                interestGroup = interestGroup
         )
 
         val clubInterest1 = ClubInterest(
@@ -702,6 +709,9 @@ class ClubDocumentation: ApiDocumentationTest() {
                                 fieldWithPath("data.interests[].interest").type(JsonFieldType.OBJECT).description("모임 관심사 정보"),
                                 fieldWithPath("data.interests[].interest.seq").type(JsonFieldType.NUMBER).description("모임 관심사 시퀀스"),
                                 fieldWithPath("data.interests[].interest.name").type(JsonFieldType.STRING).description("모임 관심사 이름"),
+                                fieldWithPath("data.interests[].interest.interestGroup").type(JsonFieldType.OBJECT).description("관심사 그룹 정보"),
+                                fieldWithPath("data.interests[].interest.interestGroup.seq").type(JsonFieldType.NUMBER).description("관심사 그룹 시퀀스"),
+                                fieldWithPath("data.interests[].interest.interestGroup.name").type(JsonFieldType.STRING).description("관심사 그룹 이름"),
                                 fieldWithPath("data.interests[].priority").type(JsonFieldType.NUMBER).description("관심사 우선순위"),
                                 fieldWithPath("data.regions").type(JsonFieldType.ARRAY).description("모임 참여지역"),
                                 fieldWithPath("data.regions[].region").type(JsonFieldType.OBJECT).description("모임 지역 정보"),

--- a/src/test/kotlin/com/taskforce/superinvention/document/interest/InterestGroupDocumentation.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/document/interest/InterestGroupDocumentation.kt
@@ -2,6 +2,7 @@ package com.taskforce.superinvention.document.interest
 
 import com.taskforce.superinvention.app.domain.interest.interest.InterestDto
 import com.taskforce.superinvention.app.domain.interest.interestGroup.InterestGroupDto
+import com.taskforce.superinvention.app.domain.interest.interestGroup.SimpleInterestGroupDto
 import com.taskforce.superinvention.config.documentation.ApiDocumentUtil.commonResponseField
 import com.taskforce.superinvention.config.documentation.ApiDocumentUtil.getDocumentRequest
 import com.taskforce.superinvention.config.documentation.ApiDocumentUtil.getDocumentResponse
@@ -28,9 +29,9 @@ class InterestGroupDocumentation: ApiDocumentationTest() {
             groupSeq = 1,
             name = "아웃도어/여행",
             interestList = listOf (
-                    InterestDto(1, "해외여행"),
-                    InterestDto(2, "국내여행"),
-                    InterestDto(3, "당일치기"))
+                    InterestDto(1, "해외여행", SimpleInterestGroupDto(1, "아웃도어/여행")),
+                    InterestDto(2, "국내여행", SimpleInterestGroupDto(1, "아웃도어/여행")),
+                    InterestDto(3, "당일치기", SimpleInterestGroupDto(1, "아웃도어/여행")))
         ))
 
         given(interestGroupService.getInterestList()).willReturn(groupList)
@@ -47,10 +48,13 @@ class InterestGroupDocumentation: ApiDocumentationTest() {
                .andDo( document("interest-group-all", getDocumentRequest(), getDocumentResponse(),
                         responseFields(
                                 *commonResponseField(),
-                                fieldWithPath("data.[].interestList").type(JsonFieldType.ARRAY).description("지역 "),
-                                fieldWithPath("data.[].interestList[].seq").type(JsonFieldType.NUMBER).description("관심 pk"),
-                                fieldWithPath("data.[].interestList[].name").type(JsonFieldType.STRING).description("세부 관심 pk"),
-                                fieldWithPath("data.[].name").type(JsonFieldType.STRING).description("관심 그룹"),
+                                fieldWithPath("data.[].interestList").type(JsonFieldType.ARRAY).description("관심사 정보"),
+                                fieldWithPath("data.[].interestList[].seq").type(JsonFieldType.NUMBER).description("관심사 시퀀스"),
+                                fieldWithPath("data.[].interestList[].name").type(JsonFieldType.STRING).description("관심사 이름"),
+                                fieldWithPath("data.[].interestList[].interestGroup").type(JsonFieldType.OBJECT).description("관심사 그룹 정보"),
+                                fieldWithPath("data.[].interestList[].interestGroup.seq").type(JsonFieldType.NUMBER).description("관심사 그룹 시퀀스"),
+                                fieldWithPath("data.[].interestList[].interestGroup.name").type(JsonFieldType.STRING).description("관심사 그룹 이름"),
+                                fieldWithPath("data.[].name").type(JsonFieldType.STRING).description("관심 그룹 이름"),
                                 fieldWithPath("data.[].groupSeq").type(JsonFieldType.NUMBER).description("관심 그룹 pk")
                         )
                ))


### PR DESCRIPTION
아래와 같이, 이제 그룹 정보가 함께 전달됩니다.

```
 "interests": [
                    {
                        "interest": {
                            "seq": 3,
                            "name": "당일치기",
                            "interestGroup": {
                                "seq": 1,
                                "name": "아웃도어/여행"
                            }
                        },
                        "priority": 1
                    }
                ],
```