### PR TITLE
내 모임 조회 시 500응답 수정 

### DIFF
--- a/src/course/rest/club/ClubInfo.http
+++ b/src/course/rest/club/ClubInfo.http
@@ -14,3 +14,9 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiIxNDUxMDAxNjQ5Iiwic3ViI
 GET http://localhost:8080/clubs/163
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
+
+### https://github.com/TASK-FORCE/super-invention/issues/180
+GET http://localhost:8080/clubs/my?size=20&page=0
+Content-Type: application/json;charset=UTF-8
+Accept: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiIxNDEyMzc1MzA5Iiwic3ViIjoiMTQxMjM3NTMwOSIsImlhdCI6MTYwNjQwNjYxMCwiZXhwIjoxNjM3OTQyNjEwfQ.j-TUvKcJMWgbYfJjnXh45XJ3wb-IvqWr_vvbMtBegb4

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/ClubRepository.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/ClubRepository.kt
@@ -129,12 +129,11 @@ class ClubRepositoryImpl(val queryFactory: JPAQueryFactory): ClubRepositoryCusto
                     club = ClubDto(
                             tuple.get(2, Club::class.java)!!
                     ),
-                    roles = toRoleSet(tuple.get(4, RoleDtoQueryProjection::class.java))
+                    roles = toRoleSet(tuple.get(3, RoleDtoQueryProjection::class.java))
             )
         }
 
         return PageImpl(result, pageable, query.total)
-
     }
 
     private fun toRoleSet(concatedRole: RoleDtoQueryProjection?): Set<RoleDto> {


### PR DESCRIPTION
모임원 수를 스칼라 서브쿼리로 가져오면서 컬럼 순서를 변경을 안해서 발생한 문제