### PR TITLE
모임 검색 시 생성일자 역순으로 정렬하여 조회

### DIFF
--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/ClubRepository.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/ClubRepository.kt
@@ -70,7 +70,7 @@ class ClubRepositoryImpl(val queryFactory: JPAQueryFactory): ClubRepositoryCusto
         // PAGING
         val fetchResult = query
                 .groupBy(club)
-                .orderBy()
+                .orderBy(club.createdAt.desc())
                 .offset(pageable.offset)
                 .limit(pageable.pageSize.toLong())
                 .fetchResults()


### PR DESCRIPTION
#183 
모임 검색시 정렬 조건 추가 [생성 역순]
정렬이 정상적으로 이루어 지지 않아서, 페이징도 정상적으로 작동하지 않았음