### PR TITLE
만남 관련 데이터 수정

### DIFF
--- a/src/course/rest/Meeting.http
+++ b/src/course/rest/Meeting.http
@@ -50,8 +50,14 @@ Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiIxNDUxMDAxNjQ5Iiwic3ViIjoiMTQ1MTAwMTY0OSIsImlhdCI6MTU5OTI4MzIxOCwiZXhwIjoxNjMwODE5MjE4fQ.v-sfReNKli476qoHc1F2yoak-n4bh_D2Db5rczwS3Bs
 Accept: application/json
 
+### 신청 취소 [준]
+DELETE localhost:8080/clubs/6164/meetings/6228/applications HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiIxNDUxMDAxNjQ5Iiwic3ViIjoiMTQ1MTAwMTY0OSIsImlhdCI6MTU5OTI4MzIxOCwiZXhwIjoxNjMwODE5MjE4fQ.v-sfReNKli476qoHc1F2yoak-n4bh_D2Db5rczwS3Bs
+Accept: application/json
+
 ### 만남 신청 정보 [준]
-GET localhost:8080/clubs/115/meetings/6111/applications/6112 HTTP/1.1
+GET localhost:8080/clubs/6164/meetings/6228/applications HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiIxNDUxMDAxNjQ5Iiwic3ViIjoiMTQ1MTAwMTY0OSIsImlhdCI6MTU5OTI4MzIxOCwiZXhwIjoxNjMwODE5MjE4fQ.v-sfReNKli476qoHc1F2yoak-n4bh_D2Db5rczwS3Bs
 Accept: application/json

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/BaseEntity.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/BaseEntity.kt
@@ -14,8 +14,8 @@ open class BaseEntity {
     var seq: Long? = null
 
     @CreatedDate
-    val createdAt: LocalDateTime? = LocalDateTime.now()
+    var createdAt: LocalDateTime? = LocalDateTime.now()
 
     @LastModifiedDate
-    val updatedAt: LocalDateTime? = LocalDateTime.now()
+    var updatedAt: LocalDateTime? = null
 }

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/ClubRepository.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/ClubRepository.kt
@@ -23,6 +23,7 @@ import com.taskforce.superinvention.app.web.dto.club.ClubUserWithUserDto
 import com.taskforce.superinvention.app.web.dto.interest.InterestRequestDto
 import com.taskforce.superinvention.app.web.dto.region.RegionRequestDto
 import com.taskforce.superinvention.app.web.dto.role.RoleDto
+import com.taskforce.superinvention.app.web.dto.user.UserDto
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
@@ -128,7 +129,7 @@ class ClubRepositoryImpl(val queryFactory: JPAQueryFactory): ClubRepositoryCusto
         val result: List<ClubUserWithUserDto> = query.results.map { tuple ->
             ClubUserWithUserDto(
                     seq = tuple.get(0, Long::class.java)!!,
-                    user = tuple.get(1, User::class.java)!!,
+                    user = UserDto(tuple.get(1, User::class.java)!!),
                     club = ClubDto(
                             tuple.get(2, Club::class.java)!!
                     ),

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/meeting/MeetingRepository.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/meeting/MeetingRepository.kt
@@ -1,6 +1,9 @@
 package com.taskforce.superinvention.app.domain.meeting
 
 import com.taskforce.superinvention.app.domain.club.QClub
+import com.taskforce.superinvention.app.domain.club.user.ClubUser
+import com.taskforce.superinvention.app.domain.club.user.QClubUser
+import com.taskforce.superinvention.app.domain.user.User
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
@@ -15,7 +18,7 @@ interface MeetingRepository : JpaRepository<Meeting, Long>, MeetingRepositoryCus
 
 
 interface MeetingRepositoryCustom {
-
+    fun findMeetingApplicationByUserAndMeetingSeq(clubUser: ClubUser, meetingSeq: Long): MeetingApplication
 }
 
 @Repository
@@ -41,4 +44,14 @@ class MeetingRepositoryImpl : QuerydslRepositorySupport(Meeting::class.java), Me
         return PageImpl(fetchResult.results, pageable, fetchResult.total)
     }
 
+    @Transactional
+    override fun findMeetingApplicationByUserAndMeetingSeq(clubUser: ClubUser, meetingSeq: Long): MeetingApplication {
+        return from(QMeetingApplication.meetingApplication)
+                .join(QMeetingApplication.meetingApplication.meeting, QMeeting.meeting)
+                .join(QMeeting.meeting.club, QClub.club)
+                .join(QClub.club.clubUser, QClubUser.clubUser)
+                .where(QClubUser.clubUser.seq.eq(clubUser.seq)
+                        , QMeeting.meeting.seq.eq(meetingSeq))
+                .fetchOne()
+    }
 }

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/meeting/MeetingService.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/meeting/MeetingService.kt
@@ -124,13 +124,18 @@ class MeetingService(
     }
 
     fun isRegUser(meetingApplication: MeetingApplicationDto, user: User): Boolean {
-        return meetingApplication.clubUser.userSeq == user.seq
+        return meetingApplication.clubUser.user.seq == user.seq
     }
 
     @Transactional
     fun getMeetingApplications(meetingSeq: Long): List<MeetingApplicationDto> {
         val meeting = meetingRepository.findById(meetingSeq)
         return meetingApplicationRepository.findByMeeting(meeting).map { MeetingApplicationDto(it) }
+    }
+
+    @Transactional
+    fun findMeetingApplication(clubUser: ClubUser, meetingSeq: Long): MeetingApplication {
+        return meetingRepository.findMeetingApplicationByUserAndMeetingSeq(clubUser, meetingSeq)
     }
 
 }

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/controller/meeting/MeetingApplicationController.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/controller/meeting/MeetingApplicationController.kt
@@ -47,6 +47,15 @@ class MeetingApplicationController(
         return ResponseDto(meetingService.applicationCancel(clubUser, meetingApplicationSeq))
     }
 
+    @DeleteMapping
+    fun cancelApplicationWithoutSeq(@AuthUser user: User,
+                                    @PathVariable("clubSeq") clubSeq: Long,
+                                    @PathVariable meetingSeq: Long): ResponseDto<MeetingApplicationDto> {
+        val clubUser = clubService.getClubUser(clubSeq, user)?: throw BizException("모임원이 아닙니다.", HttpStatus.FORBIDDEN)
+        var meetingApplication = meetingService.findMeetingApplication(clubUser, meetingSeq)
+        return cancelApplication(user, clubSeq, meetingSeq, meetingApplication.seq!!)
+    }
+
 
     @GetMapping("/{meetingApplicationSeq}")
     fun getMeetingApplicationInfo(@AuthUser user: User,
@@ -63,10 +72,19 @@ class MeetingApplicationController(
     }
 
     @GetMapping
-    fun getMeetingApplications(@AuthUser user: User,
-                                  @PathVariable("clubSeq") clubSeq: Long,
-                                  @PathVariable meetingSeq: Long): ResponseDto<List<MeetingApplicationDto>> {
-        val meetingApplications = meetingService.getMeetingApplications(meetingSeq)
-        return ResponseDto(meetingApplications)
+    fun getMeetingApplicationInfoWithoutSeq(@AuthUser user: User,
+                                    @PathVariable("clubSeq") clubSeq: Long,
+                                    @PathVariable meetingSeq: Long): ResponseDto<MeetingApplicationDto> {
+        val clubUser = clubService.getClubUser(clubSeq, user)?: throw BizException("모임원이 아닙니다.", HttpStatus.FORBIDDEN)
+        var meetingApplication = meetingService.findMeetingApplication(clubUser, meetingSeq)
+        return getMeetingApplicationInfo(user, clubSeq, meetingSeq, meetingApplication.seq!!)
     }
+
+
+//    fun getMeetingApplications(@AuthUser user: User,
+//                                  @PathVariable("clubSeq") clubSeq: Long,
+//                                  @PathVariable meetingSeq: Long): ResponseDto<List<MeetingApplicationDto>> {
+//        val meetingApplications = meetingService.getMeetingApplications(meetingSeq)
+//        return ResponseDto(meetingApplications)
+//    }
 }

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/dto/club/ClubUsersDto.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/dto/club/ClubUsersDto.kt
@@ -7,6 +7,7 @@ import com.taskforce.superinvention.app.domain.user.User
 import com.taskforce.superinvention.app.web.dto.interest.InterestWithPriorityDto
 import com.taskforce.superinvention.app.web.dto.region.SimpleRegionDto
 import com.taskforce.superinvention.app.web.dto.role.RoleDto
+import com.taskforce.superinvention.app.web.dto.user.UserDto
 
 data class ClubUsersDto(
         val club: Club,
@@ -30,13 +31,13 @@ data class ClubUserDto(
 
 data class ClubUserWithUserDto(
         val seq: Long,
-        val user: User,
+        val user: UserDto,
         val club: ClubDto,
         val roles: Set<RoleDto>
 ) {
         constructor(clubUser: ClubUser): this(
                 seq = clubUser.seq!!,
-                user = clubUser.user,
+                user = UserDto(clubUser.user),
                 club = ClubDto(clubUser.club),
                 roles = clubUser.clubUserRoles.map { e -> RoleDto(e.role) }.toSet()
         )

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/dto/meeting/MeetingApplicationDto.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/dto/meeting/MeetingApplicationDto.kt
@@ -2,17 +2,19 @@ package com.taskforce.superinvention.app.web.dto.meeting
 
 import com.taskforce.superinvention.app.domain.meeting.MeetingApplication
 import com.taskforce.superinvention.app.web.dto.club.ClubUserDto
+import com.taskforce.superinvention.app.web.dto.club.ClubUserWithUserDto
 import com.taskforce.superinvention.common.util.extendFun.toBaseDateTime
+
 class MeetingApplicationDto(
         val seq: Long,
-        val clubUser: ClubUserDto,
+        val clubUser: ClubUserWithUserDto,
         val deleteFlag: Boolean,
         val createdAt: String,
         val updatedAt: String?
 ) {
     constructor(meetingApplication: MeetingApplication): this(
             seq = meetingApplication.seq!!,
-            clubUser = ClubUserDto(meetingApplication.clubUser),
+            clubUser = ClubUserWithUserDto(meetingApplication.clubUser),
             deleteFlag = meetingApplication.deleteFlag,
             createdAt = meetingApplication.createdAt!!.toBaseDateTime(),
             updatedAt = meetingApplication.updatedAt?.toBaseDateTime() ?:""

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/dto/meeting/MeetingDto.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/dto/meeting/MeetingDto.kt
@@ -9,6 +9,9 @@ import com.taskforce.superinvention.app.domain.meeting.MeetingApplication
 import com.taskforce.superinvention.app.domain.user.User
 import com.taskforce.superinvention.app.web.dto.club.ClubDto
 import com.taskforce.superinvention.app.web.dto.club.ClubUserDto
+import com.taskforce.superinvention.app.web.dto.club.ClubUserWithUserDto
+import com.taskforce.superinvention.app.web.dto.role.RoleDto
+import com.taskforce.superinvention.app.web.dto.user.info.UserInfoDto
 import com.taskforce.superinvention.common.util.extendFun.DATE_TIME_FORMAT
 import com.taskforce.superinvention.common.util.extendFun.toBaseDateTime
 import org.springframework.format.annotation.DateTimeFormat
@@ -25,7 +28,7 @@ class MeetingDto {
     val club: ClubDto
     val deleteFlag: Boolean
     val maximumNumber: Int?
-    val regClubUser: ClubUserDto
+    val regClubUser: ClubUserWithUserDto
     var meetingApplications: List<MeetingApplicationDto>
     var isCurrentUserRegMeeting: Boolean
     var isCurrentUserApplicationMeeting: Boolean
@@ -40,7 +43,7 @@ class MeetingDto {
         club = ClubDto(meeting.club)
         deleteFlag = meeting.deleteFlag
         maximumNumber = meeting.maximumNumber
-        regClubUser = ClubUserDto(meeting.regClubUser)
+        regClubUser = ClubUserWithUserDto(meeting.regClubUser)
 
         meetingApplications = meeting.meetingApplications.map { e -> this.MeetingApplicationDto(e) }
         isCurrentUserRegMeeting = currentClubUserSeq == regClubUser.seq
@@ -56,7 +59,7 @@ class MeetingDto {
             club: ClubDto,
             deleteFlag: Boolean,
             maximumNumber: Int,
-            regClubUser: ClubUserDto,
+            regClubUser: ClubUserWithUserDto,
             meetingApplications: List<MeetingApplicationDto>,
             currentClubUserSeq: Long?,
             isCurrentUserApplicationMeeting: Boolean

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/dto/user/UserDto.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/dto/user/UserDto.kt
@@ -1,5 +1,29 @@
 package com.taskforce.superinvention.app.web.dto.user
 
+import com.taskforce.superinvention.app.domain.user.User
+import com.taskforce.superinvention.app.domain.user.UserType
+import com.taskforce.superinvention.app.domain.user.userRole.UserRole
+import com.taskforce.superinvention.app.web.dto.role.RoleDto
+import com.taskforce.superinvention.common.util.extendFun.toBaseDate
+import java.time.LocalDate
+import javax.persistence.OneToMany
+
 data class UserMemberCheckDto(
     val isMember: Boolean
 )
+
+data class UserDto(
+        var seq: Long,
+        var userRoles: Set<String>,
+        var userName: String?,
+        var birthday: String?,
+        var profileImageLink: String?
+) {
+    constructor(user: User): this(
+            seq = user.seq!!,
+            userRoles = user.userRoles.map { it.roleName }.toSet(),
+            userName = user.userName,
+            birthday = user.birthday?.toBaseDate(),
+            profileImageLink = user.profileImageLink
+    )
+}

--- a/src/main/kotlin/com/taskforce/superinvention/common/config/jpa/JpaConfig.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/common/config/jpa/JpaConfig.kt
@@ -2,6 +2,7 @@ package com.taskforce.superinvention.common.config.jpa
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 import org.springframework.orm.jpa.JpaVendorAdapter
 import org.springframework.orm.jpa.vendor.AbstractJpaVendorAdapter
 import org.springframework.orm.jpa.vendor.Database
@@ -9,6 +10,7 @@ import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter
 
 
 @Configuration
+@EnableJpaAuditing
 class JpaConfig {
 
     @Bean

--- a/src/test/kotlin/com/taskforce/superinvention/document/club/ClubDocumentation.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/document/club/ClubDocumentation.kt
@@ -19,6 +19,7 @@ import com.taskforce.superinvention.app.web.dto.region.RegionRequestDto
 import com.taskforce.superinvention.app.web.dto.region.RegionWithPriorityDto
 import com.taskforce.superinvention.app.web.dto.region.SimpleRegionDto
 import com.taskforce.superinvention.app.web.dto.role.RoleDto
+import com.taskforce.superinvention.app.web.dto.user.UserDto
 import com.taskforce.superinvention.config.documentation.ApiDocumentUtil.getDocumentRequest
 import com.taskforce.superinvention.config.documentation.ApiDocumentUtil.getDocumentResponse
 import com.taskforce.superinvention.config.test.ApiDocumentationTest
@@ -468,6 +469,7 @@ class ClubDocumentation: ApiDocumentationTest() {
     fun `내 모임 리스트 조회`() {
 
         // given
+        val pageable:Pageable =  PageRequest.of(0, 20)
         val club = Club(
                 name = "땔감 스터디",
                 description = "땔깜중에서도 고오급 땔깜이 되기 위해 노력하는 스터디",
@@ -488,7 +490,7 @@ class ClubDocumentation: ApiDocumentationTest() {
                                         clubUserDto = ClubUserWithUserDto(
                                                 seq = 12311,
                                                 club = ClubDto(club),
-                                                user = user,
+                                                user = UserDto(user),
                                                 roles = setOf(RoleDto(Role.RoleName.MEMBER, "USER_TYPE"))
                                         ),
                                         interests = clubInterestList,
@@ -498,7 +500,7 @@ class ClubDocumentation: ApiDocumentationTest() {
                                 ClubUserWithClubDetailsDto (
                                         clubUserDto = ClubUserWithUserDto(
                                                 seq = 5615,
-                                                user = user,
+                                                user = UserDto(user),
                                                 club = ClubDto(
                                                         seq = 1231,
                                                         name = "떡볶이를 좋아하는 사람들의 모임",

--- a/src/test/kotlin/com/taskforce/superinvention/document/meeting/MeetingApplicationDocumentation.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/document/meeting/MeetingApplicationDocumentation.kt
@@ -30,6 +30,7 @@ import org.springframework.restdocs.request.RequestDocumentation.*
 import org.springframework.test.web.servlet.ResultActions
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 class MeetingApplicationDocumentation: ApiDocumentationTest() {
@@ -51,8 +52,12 @@ class MeetingApplicationDocumentation: ApiDocumentationTest() {
                 mainImageUrl  = ""
         ).apply { seq = 88 }
 
-        user = User ("1").apply { seq = 2 }
-        user.userName = "eric"
+        user = User ("1").apply {
+            seq = 2
+            userName = "eric"
+            birthday = LocalDate.now()
+            profileImageLink = "asgaSGASGA.png"
+        }
 
         clubUser = ClubUser(club, user, isLiked = true).apply { seq  = 110 }
 
@@ -103,7 +108,12 @@ class MeetingApplicationDocumentation: ApiDocumentationTest() {
                                 fieldWithPath("data.seq").type(JsonFieldType.NUMBER).description("만남 신청 시퀀스"),
                                 fieldWithPath("data.clubUser").type(JsonFieldType.OBJECT).description("모임원 정보"),
                                 fieldWithPath("data.clubUser.seq").type(JsonFieldType.NUMBER).description("모임원 시퀀스"),
-                                fieldWithPath("data.clubUser.userSeq").type(JsonFieldType.NUMBER).description("회원 시퀀스"),
+                                fieldWithPath("data.clubUser.user").type(JsonFieldType.OBJECT).description("회원 정보"),
+                                fieldWithPath("data.clubUser.user.seq").type(JsonFieldType.NUMBER).description("회원 시퀀스"),
+                                fieldWithPath("data.clubUser.user.userRoles").type(JsonFieldType.ARRAY).description("회원 권한"),
+                                fieldWithPath("data.clubUser.user.userName").type(JsonFieldType.STRING).description("회원명"),
+                                fieldWithPath("data.clubUser.user.birthday").type(JsonFieldType.STRING).description("생일"),
+                                fieldWithPath("data.clubUser.user.profileImageLink").type(JsonFieldType.STRING).description("프로필 이미지 링크"),
                                 fieldWithPath("data.clubUser.club").type(JsonFieldType.OBJECT).description("모임 정보"),
                                 fieldWithPath("data.clubUser.club.seq").type(JsonFieldType.NUMBER).description("모임 시퀀스"),
                                 fieldWithPath("data.clubUser.club.name").type(JsonFieldType.STRING).description("모임명"),
@@ -151,7 +161,12 @@ class MeetingApplicationDocumentation: ApiDocumentationTest() {
                                 fieldWithPath("data.seq").type(JsonFieldType.NUMBER).description("만남 신청 시퀀스"),
                                 fieldWithPath("data.clubUser").type(JsonFieldType.OBJECT).description("모임원 정보"),
                                 fieldWithPath("data.clubUser.seq").type(JsonFieldType.NUMBER).description("모임원 시퀀스"),
-                                fieldWithPath("data.clubUser.userSeq").type(JsonFieldType.NUMBER).description("회원 시퀀스"),
+                                fieldWithPath("data.clubUser.user").type(JsonFieldType.OBJECT).description("회원 정보"),
+                                fieldWithPath("data.clubUser.user.seq").type(JsonFieldType.NUMBER).description("회원 시퀀스"),
+                                fieldWithPath("data.clubUser.user.userRoles").type(JsonFieldType.ARRAY).description("회원 권한"),
+                                fieldWithPath("data.clubUser.user.userName").type(JsonFieldType.STRING).description("회원명"),
+                                fieldWithPath("data.clubUser.user.birthday").type(JsonFieldType.STRING).description("생일"),
+                                fieldWithPath("data.clubUser.user.profileImageLink").type(JsonFieldType.STRING).description("프로필 이미지 링크"),
                                 fieldWithPath("data.clubUser.club").type(JsonFieldType.OBJECT).description("모임 정보"),
                                 fieldWithPath("data.clubUser.club.seq").type(JsonFieldType.NUMBER).description("모임 시퀀스"),
                                 fieldWithPath("data.clubUser.club.name").type(JsonFieldType.STRING).description("모임명"),
@@ -198,7 +213,12 @@ class MeetingApplicationDocumentation: ApiDocumentationTest() {
                                 fieldWithPath("data.seq").type(JsonFieldType.NUMBER).description("만남 신청 시퀀스"),
                                 fieldWithPath("data.clubUser").type(JsonFieldType.OBJECT).description("모임원 정보"),
                                 fieldWithPath("data.clubUser.seq").type(JsonFieldType.NUMBER).description("모임원 시퀀스"),
-                                fieldWithPath("data.clubUser.userSeq").type(JsonFieldType.NUMBER).description("회원 시퀀스"),
+                                fieldWithPath("data.clubUser.user").type(JsonFieldType.OBJECT).description("회원 정보"),
+                                fieldWithPath("data.clubUser.user.seq").type(JsonFieldType.NUMBER).description("회원 시퀀스"),
+                                fieldWithPath("data.clubUser.user.userRoles").type(JsonFieldType.ARRAY).description("회원 권한"),
+                                fieldWithPath("data.clubUser.user.userName").type(JsonFieldType.STRING).description("회원명"),
+                                fieldWithPath("data.clubUser.user.birthday").type(JsonFieldType.STRING).description("생일"),
+                                fieldWithPath("data.clubUser.user.profileImageLink").type(JsonFieldType.STRING).description("프로필 이미지 링크"),
                                 fieldWithPath("data.clubUser.club").type(JsonFieldType.OBJECT).description("모임 정보"),
                                 fieldWithPath("data.clubUser.club.seq").type(JsonFieldType.NUMBER).description("모임 시퀀스"),
                                 fieldWithPath("data.clubUser.club.name").type(JsonFieldType.STRING).description("모임명"),

--- a/src/test/kotlin/com/taskforce/superinvention/document/meeting/MeetingDocumentation.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/document/meeting/MeetingDocumentation.kt
@@ -6,10 +6,13 @@ import com.taskforce.superinvention.app.domain.role.Role
 import com.taskforce.superinvention.app.domain.user.User
 import com.taskforce.superinvention.app.web.dto.club.ClubDto
 import com.taskforce.superinvention.app.web.dto.club.ClubUserDto
+import com.taskforce.superinvention.app.web.dto.club.ClubUserWithUserDto
 import com.taskforce.superinvention.app.web.dto.meeting.MeetingRequestDto
 import com.taskforce.superinvention.app.web.dto.meeting.MeetingDto
 import com.taskforce.superinvention.app.web.dto.role.RoleDto
+import com.taskforce.superinvention.app.web.dto.user.UserDto
 import com.taskforce.superinvention.common.util.extendFun.DATE_TIME_FORMAT
+import com.taskforce.superinvention.common.util.extendFun.toBaseDate
 import com.taskforce.superinvention.common.util.extendFun.toBaseDateTime
 import com.taskforce.superinvention.config.MockitoHelper
 import com.taskforce.superinvention.config.documentation.ApiDocumentUtil
@@ -34,6 +37,7 @@ import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.web.servlet.ResultActions
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 class MeetingDocumentation: ApiDocumentationTest() {
@@ -68,9 +72,16 @@ class MeetingDocumentation: ApiDocumentationTest() {
             mainImageUrl = "asdasd.jpg"
     )
 
-    val clubUserDto = ClubUserDto(
+    val clubUserDto = ClubUserWithUserDto(
             seq = 512,
-            userSeq = 1,
+            user = UserDto(
+                   4,
+                   mutableSetOf(),
+                    "eric",
+                    LocalDate.now().toBaseDate(),
+                    "asfasfsaf.png"
+
+            ),
             club = clubDto,
             roles = setOf(RoleDto(Role.RoleName.CLUB_MEMBER, "CLUB_ROLE"))
     )
@@ -163,7 +174,12 @@ class MeetingDocumentation: ApiDocumentationTest() {
                                 fieldWithPath("data.content.[].maximumNumber").type(JsonFieldType.NUMBER).description("만남 최대 제한 인원"),
                                 fieldWithPath("data.content.[].regClubUser").type(JsonFieldType.OBJECT).description("만남 생성한 모임원 정보"),
                                 fieldWithPath("data.content.[].regClubUser.seq").type(JsonFieldType.NUMBER).description("모임원 시퀀스"),
-                                fieldWithPath("data.content.[].regClubUser.userSeq").type(JsonFieldType.NUMBER).description("모임원의 유저 시퀀스"),
+                                fieldWithPath("data.content.[].regClubUser.user").type(JsonFieldType.OBJECT).description("유저 정보"),
+                                fieldWithPath("data.content.[].regClubUser.user.seq").type(JsonFieldType.NUMBER).description("회원 시퀀스"),
+                                fieldWithPath("data.content.[].regClubUser.user.userRoles").type(JsonFieldType.ARRAY).description("회원 권한"),
+                                fieldWithPath("data.content.[].regClubUser.user.userName").type(JsonFieldType.STRING).description("회원명"),
+                                fieldWithPath("data.content.[].regClubUser.user.birthday").type(JsonFieldType.STRING).description("생일"),
+                                fieldWithPath("data.content.[].regClubUser.user.profileImageLink").type(JsonFieldType.STRING).description("프로필 이미지 링크"),
                                 fieldWithPath("data.content.[].regClubUser.club").type(JsonFieldType.OBJECT).description("모임원의 모임 정보"),
                                 fieldWithPath("data.content.[].regClubUser.club.seq").type(JsonFieldType.NUMBER).description("모임 시퀀스"),
                                 fieldWithPath("data.content.[].regClubUser.club.name").type(JsonFieldType.STRING).description("모임 모임명"),
@@ -239,7 +255,12 @@ class MeetingDocumentation: ApiDocumentationTest() {
                                 fieldWithPath("data.maximumNumber").type(JsonFieldType.NUMBER).description("만남 최대 제한 인원"),
                                 fieldWithPath("data.regClubUser").type(JsonFieldType.OBJECT).description("만남 생성한 모임원 정보"),
                                 fieldWithPath("data.regClubUser.seq").type(JsonFieldType.NUMBER).description("모임원 시퀀스"),
-                                fieldWithPath("data.regClubUser.userSeq").type(JsonFieldType.NUMBER).description("모임원의 유저 시퀀스"),
+                                fieldWithPath("data.regClubUser.user").type(JsonFieldType.OBJECT).description("유저 정보"),
+                                fieldWithPath("data.regClubUser.user.seq").type(JsonFieldType.NUMBER).description("회원 시퀀스"),
+                                fieldWithPath("data.regClubUser.user.userRoles").type(JsonFieldType.ARRAY).description("회원 권한"),
+                                fieldWithPath("data.regClubUser.user.userName").type(JsonFieldType.STRING).description("회원명"),
+                                fieldWithPath("data.regClubUser.user.birthday").type(JsonFieldType.STRING).description("생일"),
+                                fieldWithPath("data.regClubUser.user.profileImageLink").type(JsonFieldType.STRING).description("프로필 이미지 링크"),
                                 fieldWithPath("data.regClubUser.club").type(JsonFieldType.OBJECT).description("모임원의 모임 정보"),
                                 fieldWithPath("data.regClubUser.club.seq").type(JsonFieldType.NUMBER).description("모임 시퀀스"),
                                 fieldWithPath("data.regClubUser.club.name").type(JsonFieldType.STRING).description("모임 모임명"),
@@ -322,7 +343,12 @@ class MeetingDocumentation: ApiDocumentationTest() {
                                 fieldWithPath("data.maximumNumber").type(JsonFieldType.NUMBER).description("만남 최대 제한 인원"),
                                 fieldWithPath("data.regClubUser").type(JsonFieldType.OBJECT).description("만남 생성한 모임원 정보"),
                                 fieldWithPath("data.regClubUser.seq").type(JsonFieldType.NUMBER).description("모임원 시퀀스"),
-                                fieldWithPath("data.regClubUser.userSeq").type(JsonFieldType.NUMBER).description("모임원의 유저 시퀀스"),
+                                fieldWithPath("data.regClubUser.user").type(JsonFieldType.OBJECT).description("유저 정보"),
+                                fieldWithPath("data.regClubUser.user.seq").type(JsonFieldType.NUMBER).description("회원 시퀀스"),
+                                fieldWithPath("data.regClubUser.user.userRoles").type(JsonFieldType.ARRAY).description("회원 권한"),
+                                fieldWithPath("data.regClubUser.user.userName").type(JsonFieldType.STRING).description("회원명"),
+                                fieldWithPath("data.regClubUser.user.birthday").type(JsonFieldType.STRING).description("생일"),
+                                fieldWithPath("data.regClubUser.user.profileImageLink").type(JsonFieldType.STRING).description("프로필 이미지 링크"),
                                 fieldWithPath("data.regClubUser.club").type(JsonFieldType.OBJECT).description("모임원의 모임 정보"),
                                 fieldWithPath("data.regClubUser.club.seq").type(JsonFieldType.NUMBER).description("모임 시퀀스"),
                                 fieldWithPath("data.regClubUser.club.name").type(JsonFieldType.STRING).description("모임 모임명"),


### PR DESCRIPTION
1. 만남 - 모임원 조회 시 모임원의 유저 상세 정보를 같이 전달
2. 만남 신청 취소 시 시퀀스 없이도 취소 가능
3. https://github.com/orgs/TASK-FORCE/projects/27 관련 수정. User 엔티티를 그대로 전달하던 DTO를 UserDto를 통해 전달하도록 변경
4. 테스트코드와 문서 변경