### PR TITLE
지역 조회 N+1 버그 수정

### DIFF
--- a/src/course/rest/region/region.http
+++ b/src/course/rest/region/region.http
@@ -1,0 +1,4 @@
+### [로컬]
+GET http://localhost:8080/regions
+Content-Type: application/json;charset=UTF-8
+Accept: application/json

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/region/Region.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/region/Region.kt
@@ -6,14 +6,18 @@ import javax.persistence.*
 
 @Entity
 class Region(
+
         @ManyToOne(fetch = FetchType.LAZY)
-        @JoinColumn(name="super_region_seq")
+        @JoinColumn(name="super_region_seq", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
         @JsonIgnore
         var superRegion: Region?,
         var name: String,
         var superRegionRoot: String,
-        var level: Long,
+        var level: Long
 
-        @OneToMany(mappedBy = "superRegion")
-        var subRegions: List<Region>
-): BaseEntity()
+): BaseEntity() {
+
+        @OneToMany
+        @JoinColumn(name="super_region_seq", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
+        var subRegions: List<Region> = listOf()
+}

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/region/RegionRepository.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/region/RegionRepository.kt
@@ -1,9 +1,31 @@
 package com.taskforce.superinvention.app.domain.region
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
 import org.springframework.stereotype.Repository
 
 @Repository
-interface RegionRepository : JpaRepository<Region, Long> {
-    fun findByLevel(level: Long): List<Region>
+interface RegionRepository : JpaRepository<Region, Long>, RegionRepositoryCustom {
+
+}
+
+interface RegionRepositoryCustom {
+    fun findByLevelWithSubRegions(): List<Region>
+}
+
+@Repository
+class RegionRepositoryImpl: RegionRepositoryCustom,
+    QuerydslRepositorySupport(Region::class.java) {
+
+    override fun findByLevelWithSubRegions(): List<Region> {
+        val superRegion = QRegion.region
+        val subRegion = QRegion("r2")
+
+        val result = from(superRegion)
+            .join(superRegion.subRegions, subRegion).fetchJoin()
+            .where(superRegion.superRegion.isNull)
+
+        val fetch = result.fetch().distinct()
+        return fetch
+    }
 }

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/region/RegionService.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/region/RegionService.kt
@@ -13,7 +13,8 @@ class RegionService(
 ) {
     @Transactional
     fun findAllRegionDtoList(): List<RegionDto> {
-        return regionRepository.findByLevel(1).map { e -> of(e, 1) }.toList()
+        val regions = regionRepository.findByLevelWithSubRegions().map { of(it, it.subRegions) }
+        return regions
     }
 
     fun findBySeq(seq: Long): Region = regionRepository.findById(seq).orElseThrow{IllegalArgumentException()}

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/dto/region/RegionDto.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/dto/region/RegionDto.kt
@@ -34,6 +34,25 @@ fun of(region: Region, findDepth: Long): RegionDto
              name = region.name,
              superRegionRoot = region.superRegionRoot,
              level = region.level,
-             subRegions = if (findDepth > 0) region.subRegions.stream().map { e -> of(e, findDepth - 1) }.toList() else ArrayList()
+             subRegions = if (findDepth > 0) region.subRegions.map { e -> of(e, findDepth - 1) }.toList() else emptyList()
      )
  }
+
+
+fun of(region: Region, subRegions: List<Region>): RegionDto
+{
+    return RegionDto(
+        seq = region.seq,
+        name = region.name,
+        superRegionRoot = region.superRegionRoot,
+        level = region.level,
+        subRegions = subRegions.map {
+            RegionDto(
+                seq = it.seq,
+                name = it.name,
+                superRegionRoot = it.superRegionRoot,
+                level = it.level,
+                subRegions = emptyList()
+            ) }
+    )
+}

--- a/src/main/kotlin/com/taskforce/superinvention/common/config/jpa/JpaConfig.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/common/config/jpa/JpaConfig.kt
@@ -2,6 +2,7 @@ package com.taskforce.superinvention.common.config.jpa
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 import org.springframework.orm.jpa.JpaVendorAdapter
 import org.springframework.orm.jpa.vendor.AbstractJpaVendorAdapter
 import org.springframework.orm.jpa.vendor.Database
@@ -9,6 +10,7 @@ import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter
 
 
 @Configuration
+@EnableJpaAuditing
 class JpaConfig {
 
     @Bean

--- a/src/test/kotlin/com/taskforce/superinvention/document/club/ClubDocumentation.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/document/club/ClubDocumentation.kt
@@ -276,8 +276,7 @@ class ClubDocumentation: ApiDocumentationTest() {
                 superRegion = null,
                 name = "성남시",
                 superRegionRoot = "경기도/성남시",
-                level = 2,
-                subRegions = listOf()
+                level = 2
         ).apply { seq = 401 }
 
         val clubRegion = ClubRegion(club, region1, 1).apply { seq = 41231 }
@@ -610,17 +609,15 @@ class ClubDocumentation: ApiDocumentationTest() {
                 superRegion = null,
                 name = "성남시",
                 superRegionRoot = "경기도/성남시",
-                level = 2,
-                subRegions = listOf()
-        ).apply { seq = 401 }
+                level = 2
+        ).apply { seq = 401; }
 
         val region2 = Region(
                 superRegion = null,
                 name = "강남구",
                 level = 2,
-                subRegions = listOf(),
                 superRegionRoot = "서울특별시/강남구"
-        ).apply { seq = 123 }
+        ).apply { seq = 123; }
 
         val clubRegion = ClubRegion(club, region1, 1).apply { seq = 41231 }
         val clubRegion2 = ClubRegion(club, region2, 2).apply { seq = 41231 }

--- a/src/test/kotlin/com/taskforce/superinvention/document/club/ClubInfoDocumentation.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/document/club/ClubInfoDocumentation.kt
@@ -70,8 +70,7 @@ class ClubInfoDocumentation: ApiDocumentationTestV2() {
                 superRegion = null,
                 name = "성남시",
                 superRegionRoot = "경기도/성남시",
-                level = 2,
-                subRegions = listOf()
+                level = 2
         ).apply { seq = 401 }
     }
 

--- a/src/test/kotlin/com/taskforce/superinvention/document/region/RegionDocumentation.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/document/region/RegionDocumentation.kt
@@ -27,7 +27,6 @@ class RegionDocumentation: ApiDocumentationTest() {
                 level = 1,
                 name = "서울특별시",
                 superRegionRoot = "서울특별시",
-                subRegions = emptyList(),
                 superRegion = null
         ).apply { seq = 1 }
 

--- a/src/test/kotlin/com/taskforce/superinvention/document/user/UserDocumentation.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/document/user/UserDocumentation.kt
@@ -162,8 +162,8 @@ class UserDocumentation : ApiDocumentationTest() {
     fun `유저 지역 조회`() {
 
         // given
-        val region1 = Region(superRegion = null, name = "성남시", superRegionRoot = "경기도/성남시", level = 2, subRegions = listOf()).apply {seq = 1001}
-        val region2 = Region(superRegion = null, name = "수원시", superRegionRoot = "경기도/수원시", level = 2, subRegions = listOf()).apply {seq = 1002}
+        val region1 = Region(superRegion = null, name = "성남시", superRegionRoot = "경기도/성남시", level = 2).apply {seq = 1001;}
+        val region2 = Region(superRegion = null, name = "수원시", superRegionRoot = "경기도/수원시", level = 2).apply {seq = 1002;}
 
         val regionWithPriorityDto1 = RegionWithPriorityDto(
                 region = SimpleRegionDto(region1)
@@ -268,15 +268,14 @@ class UserDocumentation : ApiDocumentationTest() {
             userId = "12313"
         }
 
-        val superRegion= Region(name="서울특별시", superRegionRoot = "서울특별시", level = 2L, superRegion = null, subRegions = listOf()).apply { seq  = 1 }
-        val region1 = Region(name="종로구", superRegionRoot = "서울특별시/종로구", level = 2L, superRegion = superRegion, subRegions = listOf()).apply { seq = 101L }
-        val region2 = Region(name="중구", superRegionRoot = "서울특별시/중구", level = 2L, superRegion = superRegion, subRegions = listOf()).apply { seq = 102L }
+        val superRegion= Region(name="서울특별시", superRegionRoot = "서울특별시", level = 2L, superRegion = null).apply { seq  = 1; }
+        val region1 = Region(name="종로구", superRegionRoot = "서울특별시/종로구", level = 2L, superRegion = superRegion).apply { seq = 101L;}
+        val region2 = Region(name="중구", superRegionRoot = "서울특별시/중구", level = 2L, superRegion = superRegion).apply { seq = 102L; }
 
         val userRegions = listOf(
                 RegionWithPriorityDto(region = SimpleRegionDto(region = region1), priority = 1L),
                 RegionWithPriorityDto(region = SimpleRegionDto(region = region2), priority = 2L)
         )
-
 
         val regionRequest = listOf(RegionRequestDto(seq = 101L, priority = 1L), RegionRequestDto(seq = 102L, priority = 2L))
         val userRegionDto = UserRegionDto(user = mockUser, regions = userRegions)
@@ -455,9 +454,9 @@ class UserDocumentation : ApiDocumentationTest() {
 
 
         // given - userInfoRegion Data set
-        val superRegion= Region(name="서울특별시", superRegionRoot = "서울특별시", level = 2L, superRegion = null, subRegions = listOf()).apply { seq  = 1 }
-        val region1    = Region(name="종로구", superRegionRoot = "서울특별시/종로구", level = 2L, superRegion = superRegion, subRegions = listOf()).apply { seq = 101L }
-        val region2    = Region(name="중구", superRegionRoot = "서울특별시/중구", level = 2L, superRegion = superRegion, subRegions = listOf()).apply { seq = 102L }
+        val superRegion= Region(name="서울특별시", superRegionRoot = "서울특별시", level = 2L, superRegion = null).apply { seq  = 1; }
+        val region1    = Region(name="종로구", superRegionRoot = "서울특별시/종로구", level = 2L, superRegion = superRegion).apply { seq = 101L; }
+        val region2    = Region(name="중구", superRegionRoot = "서울특별시/중구", level = 2L, superRegion = superRegion).apply { seq = 102L; }
 
 
         val userInfoRegions: List<UserInfoRegionDto> = listOf(


### PR DESCRIPTION
이걸 드디어 고치는군요 ㅋㅋㅋ ;;

지역 조회시 N+1 때문에 100개 이상의 쿼리가 날라가던 문제 해결

```sql
SELECT *
FROM region r
    JOIN region r2
        on r.seq = r2.super_region_seq
where r.super_region_seq is null;

```



### 개선 전
![sssss](https://user-images.githubusercontent.com/50672087/102002839-d0cb0000-3d43-11eb-96ef-5cd482842d7b.PNG)

### 개선 후
![dd](https://user-images.githubusercontent.com/50672087/102002838-cf99d300-3d43-11eb-8b2e-b60635d4251a.PNG)