### PR TITLE
유저 앱토큰으로 조회하도록 변경

### DIFF
--- a/src/main/kotlin/com/taskforce/superinvention/app/web/controller/user/UserController.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/controller/user/UserController.kt
@@ -13,6 +13,7 @@ import com.taskforce.superinvention.app.web.dto.user.UserMemberCheckDto
 import com.taskforce.superinvention.app.web.dto.user.info.UserInfoDto
 import com.taskforce.superinvention.common.config.argument.auth.AuthUser
 import com.taskforce.superinvention.common.config.security.AppToken
+import com.taskforce.superinvention.common.config.security.JwtTokenProvider
 import com.taskforce.superinvention.common.exception.BizException
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
@@ -23,7 +24,8 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/users")
 class UserController(
         private val userService: UserService,
-        private val userInfoService: UserInfoService
+        private val userInfoService: UserInfoService,
+        private val jwtTokenProvider: JwtTokenProvider
 ) {
 
     @Value("\${spring.profiles.active}")
@@ -71,7 +73,9 @@ class UserController(
     fun backdoorUserToken(@PathVariable username: String): ResponseDto<String> {
         if (profile != "dev") throw BizException("개발서버에서만 가능한 동작입니다.")
         var user = userService.getUserByUsername(username)
-        return ResponseDto(user.accessToken!!)
+        val appToken = jwtTokenProvider.createAppToken(user.userId)
+
+        return ResponseDto(appToken)
     }
 
     @GetMapping("/door")


### PR DESCRIPTION
#253 간단한 버그 픽스입니다. 유저 토큰 조회시 유저의 Access Token이 아닌, App Token을 내려주도록 변경하였습니다.