### PR TITLE
만남 조회가 되지 않던 이슈 해결

### DIFF
--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/meeting/MeetingRepository.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/meeting/MeetingRepository.kt
@@ -32,7 +32,6 @@ class MeetingRepositoryImpl : QuerydslRepositorySupport(Meeting::class.java), Me
                 .fetchJoin()
                 .where(QClub.club.seq.eq(clubSeq)
                         , QMeeting.meeting.deleteFlag.isFalse
-                        , QMeetingApplication.meetingApplication.deleteFlag.isFalse
                 )
 
         val fetchResult = query

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/meeting/MeetingService.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/meeting/MeetingService.kt
@@ -37,7 +37,13 @@ class MeetingService(
     @Transactional(readOnly = true)
     fun getMeetings(clubSeq: Long, pageable: Pageable, currentClubUserSeq: Long?): PageDto<MeetingDto> {
 
-        val resultPage = meetingRepositoryImpl.getMeetings(clubSeq, pageable).map { e -> MeetingDto(e, currentClubUserSeq) }
+        val resultPage = meetingRepositoryImpl
+            .getMeetings(clubSeq, pageable)
+            .map { e -> MeetingDto(e, currentClubUserSeq)
+                .apply {
+                    meetingApplications = meetingApplications.filterNot { it.deleteFlag }
+                }
+            }
         return PageDto(resultPage)
     }
 


### PR DESCRIPTION
#235 
쿼리단에서 만남 신청이 없을 경우, 만남을 불러오지 못하던 문제가 있었음.
쿼리단에서는 모두 조회하고, 만남 신청을 비즈니스 로직단에서 걸러주는 방향으로 변경.