### PR TITLE
group_concat에 대한 문법에러 수정

### DIFF
--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/ClubRepository.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/ClubRepository.kt
@@ -105,8 +105,8 @@ class ClubRepositoryImpl(val queryFactory: JPAQueryFactory): ClubRepositoryCusto
         val clubUserRole = QClubUserRole.clubUserRole
         val roleGroup = QRoleGroup.roleGroup;
 
-        val groupConcatRole      = Expressions.stringTemplate("group_concat({0}, ' ')", clubUserRole.role.name)
-        val groupConcatRoleGroup = Expressions.stringTemplate("group_concat({0}, ' ')", clubUserRole.role.roleGroup.name)
+        val groupConcatRole      = Expressions.stringTemplate("group_concat({0})", clubUserRole.role.name)
+        val groupConcatRoleGroup = Expressions.stringTemplate("group_concat({0})", clubUserRole.role.roleGroup.name)
 
         val query =
                 from(clubUserRole)


### PR DESCRIPTION
`Expressions.stringTemplate("group_concat({0}, ' ')", clubUserRole.role.name)` 이 부분을
`Expressions.stringTemplate("group_concat({0})", clubUserRole.role.name)` 로 바꾸어 에러 발생을 수정해두었습니다. 세퍼레이터 관련 문법에 약간 오류가 있었던듯 하네요.