### PR TITLE
모임 게시판 게시글 카테고리별 검색 api 추가

### DIFF
--- a/src/course/rest/club/board/ClubBoard.http
+++ b/src/course/rest/club/board/ClubBoard.http
@@ -16,10 +16,11 @@ Authorization: Bearer {{token-sdm}}
 }
 
 ### 모임 게시판 조회
-GET {{host}}/clubs/6174/board
+GET {{host}}/clubs/6174/board?category=NOTICE
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
 Authorization: Bearer {{token-sdm}}
+GlobalAdviceController
 
 ### 모임 게시판 단일 조회
 GET {{host}}/clubs/6174/board/2

--- a/src/docs/asciidoc/club/board/club-board-select-list.adoc
+++ b/src/docs/asciidoc/club/board/club-board-select-list.adoc
@@ -1,0 +1,19 @@
+ifndef::snippets[]
+:sub-snippet: ../../../../../build/generated-snippets
+endif::[]
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:sectlinks:
+:site-url: /build/asciidoc/html5/state
+
+Request
+include::{sub-snippet}/select-club-board-list/http-request.adoc[]
+include::{sub-snippet}/select-club-board-list/request-parameters.adoc[]
+
+
+Response
+include::{sub-snippet}/select-club-board-list/response-fields.adoc[]
+include::{sub-snippet}/select-club-board-list/response-body.adoc[]

--- a/src/docs/asciidoc/club/board/club-board-select.adoc
+++ b/src/docs/asciidoc/club/board/club-board-select.adoc
@@ -11,8 +11,6 @@ endif::[]
 
 Request
 include::{sub-snippet}/select-club-board/http-request.adoc[]
-include::{sub-snippet}/select-club-board/request-parameters.adoc[]
-
 
 Response
 include::{sub-snippet}/select-club-board/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -111,7 +111,10 @@ include::{root}/club/kick.adoc[]
 === [.toc-list-item]`모임 게시판 작성`
 include::{root}/club/board/club-board-register.adoc[]
 
-=== [.toc-list-item]`모임 게시판 조회`
+=== [.toc-list-item]`모임 게시판 목록 조회`
+include::{root}/club/board/club-board-select-list.adoc[]
+
+=== [.toc-list-item]`모임 게시판 단건 조회`
 include::{root}/club/board/club-board-select.adoc[]
 
 === [.toc-list-item]`모임 게시판 삭제`

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/ClubBoardService.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/ClubBoardService.kt
@@ -42,10 +42,10 @@ class ClubBoardService(
      * 게시판 글 목록 조회
      */
     @Transactional
-    fun getClubBoardList(pageable: Pageable, searchOpt: ClubBoardSearchOpt, clubSeq: Long): PageDto<ClubBoardListViewDto> {
+    fun getClubBoardList(pageable: Pageable, category: ClubBoard.Category?, searchOpt: ClubBoardSearchOpt, clubSeq: Long): PageDto<ClubBoardListViewDto> {
         val pageRequest: Pageable = PageRequest.of(pageable.pageNumber, pageable.pageSize)
 
-        val resultPage = clubBoardRepository.searchInList(pageRequest, searchOpt, clubSeq)
+        val resultPage = clubBoardRepository.searchInList(pageRequest, category, searchOpt, clubSeq)
             .map(::ClubBoardListViewDto)
 
         return PageDto(resultPage)

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/controller/club/ClubController.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/controller/club/ClubController.kt
@@ -12,8 +12,7 @@ import com.taskforce.superinvention.app.web.dto.club.*
 import com.taskforce.superinvention.app.web.dto.common.PageDto
 import com.taskforce.superinvention.app.web.dto.interest.InterestRequestDto
 import com.taskforce.superinvention.app.web.dto.region.RegionRequestDto
-import com.taskforce.superinvention.app.web.dto.role.RoleDto
-import com.taskforce.superinvention.common.config.argument.auth.AuthUser
+import com.taskforce.superinvention.common.config.argument.resolver.auth.AuthUser
 import com.taskforce.superinvention.common.exception.BizException
 import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/controller/club/album/ClubAlbumCommentController.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/controller/club/album/ClubAlbumCommentController.kt
@@ -6,7 +6,7 @@ import com.taskforce.superinvention.app.web.common.response.ResponseDto
 import com.taskforce.superinvention.app.web.dto.club.album.comment.ClubAlbumCommentListDto
 import com.taskforce.superinvention.app.web.dto.club.album.comment.ClubAlbumCommentRegisterDto
 import com.taskforce.superinvention.app.web.dto.common.PageDto
-import com.taskforce.superinvention.common.config.argument.auth.AuthUser
+import com.taskforce.superinvention.common.config.argument.resolver.auth.AuthUser
 import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/controller/club/album/ClubAlbumController.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/controller/club/album/ClubAlbumController.kt
@@ -8,7 +8,7 @@ import com.taskforce.superinvention.app.web.dto.club.album.ClubAlbumListDto
 import com.taskforce.superinvention.app.web.dto.club.album.ClubAlbumRegisterDto
 import com.taskforce.superinvention.app.web.dto.club.album.ClubAlbumSearchOption
 import com.taskforce.superinvention.app.web.dto.common.PageDto
-import com.taskforce.superinvention.common.config.argument.auth.AuthUser
+import com.taskforce.superinvention.common.config.argument.resolver.auth.AuthUser
 import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/controller/club/album/ClubAlbumLikeController.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/controller/club/album/ClubAlbumLikeController.kt
@@ -4,7 +4,7 @@ import com.taskforce.superinvention.app.domain.club.album.like.ClubAlbumLikeServ
 import com.taskforce.superinvention.app.domain.user.User
 import com.taskforce.superinvention.app.web.common.response.ResponseDto
 import com.taskforce.superinvention.app.web.dto.club.album.like.ClubAlbumLikeDto
-import com.taskforce.superinvention.common.config.argument.auth.AuthUser
+import com.taskforce.superinvention.common.config.argument.resolver.auth.AuthUser
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/controller/club/board/ClubBoardCommentController.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/controller/club/board/ClubBoardCommentController.kt
@@ -6,7 +6,7 @@ import com.taskforce.superinvention.app.web.common.response.ResponseDto
 import com.taskforce.superinvention.app.web.dto.club.board.comment.ClubBoardCommentListDto
 import com.taskforce.superinvention.app.web.dto.club.board.comment.ClubBoardCommentRegisterDto
 import com.taskforce.superinvention.app.web.dto.common.PageDto
-import com.taskforce.superinvention.common.config.argument.auth.AuthUser
+import com.taskforce.superinvention.common.config.argument.resolver.auth.AuthUser
 import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/controller/club/board/ClubBoardController.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/controller/club/board/ClubBoardController.kt
@@ -1,5 +1,6 @@
 package com.taskforce.superinvention.app.web.controller.club.board
 
+import com.taskforce.superinvention.app.domain.club.board.ClubBoard
 import com.taskforce.superinvention.app.domain.club.board.ClubBoardService
 import com.taskforce.superinvention.app.domain.user.User
 import com.taskforce.superinvention.app.web.common.response.ResponseDto
@@ -8,7 +9,7 @@ import com.taskforce.superinvention.app.web.dto.club.board.ClubBoardRegisterBody
 import com.taskforce.superinvention.app.web.dto.club.board.ClubBoardListViewDto
 import com.taskforce.superinvention.app.web.dto.club.board.ClubBoardSearchOpt
 import com.taskforce.superinvention.app.web.dto.common.PageDto
-import com.taskforce.superinvention.common.config.argument.auth.AuthUser
+import com.taskforce.superinvention.common.config.argument.resolver.auth.AuthUser
 import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
@@ -23,11 +24,12 @@ class ClubBoardController(
      * 모임 게시판 글 조회
      */
     @GetMapping("/{clubSeq}/board")
-    fun getClubBoardList(@PathVariable clubSeq: Long,
-                         pageable: Pageable,
+    fun getClubBoardList(pageable: Pageable,
+                         @PathVariable clubSeq: Long,
+                         @RequestParam(required = false) category: ClubBoard.Category?,
                          searchRequest: ClubBoardSearchOpt): ResponseDto<PageDto<ClubBoardListViewDto>> {
 
-        val search = clubBoardService.getClubBoardList(pageable, searchRequest, clubSeq)
+        val search = clubBoardService.getClubBoardList(pageable, category, searchRequest, clubSeq)
         return ResponseDto(data = search)
     }
 

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/controller/club/board/ClubBoardLikeController.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/controller/club/board/ClubBoardLikeController.kt
@@ -1,12 +1,10 @@
 package com.taskforce.superinvention.app.web.controller.club.board
 
-import com.taskforce.superinvention.app.domain.club.album.like.ClubAlbumLikeService
 import com.taskforce.superinvention.app.domain.club.board.like.ClubBoardLikeService
 import com.taskforce.superinvention.app.domain.user.User
 import com.taskforce.superinvention.app.web.common.response.ResponseDto
-import com.taskforce.superinvention.app.web.dto.club.album.like.ClubAlbumLikeDto
 import com.taskforce.superinvention.app.web.dto.club.board.like.ClubBoardLikeDto
-import com.taskforce.superinvention.common.config.argument.auth.AuthUser
+import com.taskforce.superinvention.common.config.argument.resolver.auth.AuthUser
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/controller/meeting/MeetingApplicationController.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/controller/meeting/MeetingApplicationController.kt
@@ -8,7 +8,7 @@ import com.taskforce.superinvention.app.domain.user.User
 import com.taskforce.superinvention.app.web.common.response.ResponseDto
 import com.taskforce.superinvention.app.web.dto.meeting.MeetingApplicationDto
 import com.taskforce.superinvention.app.web.dto.meeting.MeetingApplicationStatusDto
-import com.taskforce.superinvention.common.config.argument.auth.AuthUser
+import com.taskforce.superinvention.common.config.argument.resolver.auth.AuthUser
 import com.taskforce.superinvention.common.exception.BizException
 import org.springframework.http.HttpStatus
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/controller/meeting/MeetingController.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/controller/meeting/MeetingController.kt
@@ -9,7 +9,7 @@ import com.taskforce.superinvention.app.web.common.response.ResponseDto
 import com.taskforce.superinvention.app.web.dto.common.PageDto
 import com.taskforce.superinvention.app.web.dto.meeting.MeetingRequestDto
 import com.taskforce.superinvention.app.web.dto.meeting.MeetingDto
-import com.taskforce.superinvention.common.config.argument.auth.AuthUser
+import com.taskforce.superinvention.common.config.argument.resolver.auth.AuthUser
 import com.taskforce.superinvention.common.exception.BizException
 import com.taskforce.superinvention.common.exception.club.UserIsNotClubMemberException
 import org.springframework.data.domain.Pageable

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/controller/user/UserController.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/controller/user/UserController.kt
@@ -11,7 +11,7 @@ import com.taskforce.superinvention.app.web.dto.kakao.KakaoUserRegistRequest
 import com.taskforce.superinvention.app.web.dto.user.UserIdAndNameDto
 import com.taskforce.superinvention.app.web.dto.user.UserMemberCheckDto
 import com.taskforce.superinvention.app.web.dto.user.info.UserInfoDto
-import com.taskforce.superinvention.common.config.argument.auth.AuthUser
+import com.taskforce.superinvention.common.config.argument.resolver.auth.AuthUser
 import com.taskforce.superinvention.common.config.security.AppToken
 import com.taskforce.superinvention.common.config.security.JwtTokenProvider
 import com.taskforce.superinvention.common.exception.BizException

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/controller/user/UserInterestController.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/controller/user/UserInterestController.kt
@@ -6,7 +6,7 @@ import com.taskforce.superinvention.app.domain.user.userInterest.UserInterestSer
 import com.taskforce.superinvention.app.web.common.response.ResponseDto
 import com.taskforce.superinvention.app.web.dto.interest.InterestRequestDto
 import com.taskforce.superinvention.app.web.dto.interest.UserInterestDto
-import com.taskforce.superinvention.common.config.argument.auth.AuthUser
+import com.taskforce.superinvention.common.config.argument.resolver.auth.AuthUser
 import org.springframework.security.access.annotation.Secured
 import org.springframework.web.bind.annotation.*
 

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/controller/user/UserRegionController.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/controller/user/UserRegionController.kt
@@ -3,11 +3,10 @@ package com.taskforce.superinvention.app.web.controller.user
 import com.taskforce.superinvention.app.domain.role.Role
 import com.taskforce.superinvention.app.domain.user.User
 import com.taskforce.superinvention.app.domain.user.userRegion.UserRegionService
-import com.taskforce.superinvention.app.domain.user.userRole.UserRole
 import com.taskforce.superinvention.app.web.common.response.ResponseDto
 import com.taskforce.superinvention.app.web.dto.region.RegionRequestDto
 import com.taskforce.superinvention.app.web.dto.user.UserRegionDto
-import com.taskforce.superinvention.common.config.argument.auth.AuthUser
+import com.taskforce.superinvention.common.config.argument.resolver.auth.AuthUser
 import org.springframework.security.access.annotation.Secured
 import org.springframework.web.bind.annotation.*
 

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/dto/club/board/ClubBoardRegisterBody.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/dto/club/board/ClubBoardRegisterBody.kt
@@ -21,27 +21,33 @@ data class ClubBoardRegisterBody(
 
 class ClubBoardSearchOpt(
         val title  : String = "",
-        val content: String = ""
+        val content: String = "",
 )
 
 // 모임 게시판 단일 조회
 data class ClubBoardDto(
-        val clubBoardSeq: Long,
+        val boardSeq: Long,
         val title      : String,
         val content    : String,
+        val category   : ClubBoard.Category,
+        val likeCnt    : Long,
+        val commentCnt : Long,
         val createdAt  : String,
         val updatedAt  : String,
-        val boardImgs  : List<ClubBoardImg>,
+        val imageList  : List<ClubBoardImg>,
         val writer     : ClubWriter
 ) {
     constructor(clubBoard: ClubBoard): this(
-            clubBoardSeq = clubBoard.seq!!,
-            title     = clubBoard.title,
-            content   = clubBoard.content,
-            createdAt = clubBoard.createdAt?.toBaseDateTime() ?: "",
-            updatedAt = clubBoard.updatedAt?.toBaseDateTime() ?: "",
-            boardImgs = clubBoard.boardImgs,
-            writer    = ClubWriter(clubBoard.clubUser)
+            boardSeq   = clubBoard.seq!!,
+            title      = clubBoard.title,
+            content    = clubBoard.content,
+            category   = clubBoard.category,
+            likeCnt    = clubBoard.boardLikeCnt    ?: 0,
+            commentCnt = clubBoard.boardCommentCnt ?: 0,
+            createdAt  = clubBoard.createdAt?.toBaseDateTime() ?: "",
+            updatedAt  = clubBoard.updatedAt?.toBaseDateTime() ?: "",
+            imageList  = clubBoard.boardImgs,
+            writer     = ClubWriter(clubBoard.clubUser)
     )
 }
 

--- a/src/main/kotlin/com/taskforce/superinvention/common/advice/GlobalAdviceController.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/common/advice/GlobalAdviceController.kt
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.context.request.WebRequest
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 
 @RestControllerAdvice
 @RestController
@@ -25,6 +26,12 @@ class GlobalAdviceController {
     fun bizExceptionAdvice(e: BizException, webRequest: WebRequest): ResponseEntity<ErrorResponse> {
         LOG.error("${e.message}\n${e.stackTrace.joinToString("\n")}")
         return ResponseEntity(ErrorResponse(e.message), e.httpStatus)
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+    fun globalMethodArgumentNotMatchAdvice(e: Exception, webRequest: WebRequest): ResponseEntity<ErrorResponse> {
+        LOG.error("${e.cause?.message ?: ""}\n${e.cause?.stackTrace?.joinToString("\n") ?: ""}")
+        return ResponseEntity(ErrorResponse(message = e.cause?.cause?.message ?: ""), HttpStatus.BAD_REQUEST)
     }
 
     @ExceptionHandler(Exception::class)

--- a/src/main/kotlin/com/taskforce/superinvention/common/config/WebMvcConfig.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/common/config/WebMvcConfig.kt
@@ -1,12 +1,13 @@
 package com.taskforce.superinvention.common.config
 
-import com.taskforce.superinvention.common.config.argument.auth.AuthorizeArgumentResolver
+import com.taskforce.superinvention.common.config.argument.converter.ClubBoardCategoryConverter
+import com.taskforce.superinvention.common.config.argument.resolver.auth.AuthorizeArgumentResolver
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver
+import org.springframework.format.FormatterRegistry
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport
-import org.springframework.format.FormatterRegistry
 
 @Configuration
 class WebMvcConfig(
@@ -21,5 +22,9 @@ class WebMvcConfig(
     override fun addArgumentResolvers(argumentResolvers: MutableList<HandlerMethodArgumentResolver>) {
         argumentResolvers.add(authorizeArgumentResolver)
         argumentResolvers.add(PageableHandlerMethodArgumentResolver());
+    }
+
+    override fun addFormatters(registry: FormatterRegistry) {
+        registry.addConverter(ClubBoardCategoryConverter())
     }
 }

--- a/src/main/kotlin/com/taskforce/superinvention/common/config/argument/converter/ClubBoardCategoryConverter.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/common/config/argument/converter/ClubBoardCategoryConverter.kt
@@ -1,0 +1,13 @@
+package com.taskforce.superinvention.common.config.argument.converter
+
+import com.taskforce.superinvention.app.domain.club.board.ClubBoard
+import com.taskforce.superinvention.common.exception.InvalidInputException
+import org.springframework.core.convert.converter.Converter
+
+class ClubBoardCategoryConverter: Converter<String, ClubBoard.Category> {
+
+    override fun convert(source: String): ClubBoard.Category {
+        return ClubBoard.Category.fromCategoryLabel(source)
+            ?: throw InvalidInputException(message = "해당 카테고리로를 검색할 수 없습니다.")
+    }
+}

--- a/src/main/kotlin/com/taskforce/superinvention/common/config/argument/resolver/auth/AuthorizeArgumentResolver.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/common/config/argument/resolver/auth/AuthorizeArgumentResolver.kt
@@ -1,4 +1,4 @@
-package com.taskforce.superinvention.common.config.argument.auth
+package com.taskforce.superinvention.common.config.argument.resolver.auth
 
 import com.taskforce.superinvention.app.domain.user.User
 import com.taskforce.superinvention.app.domain.user.UserRepository
@@ -6,7 +6,6 @@ import com.taskforce.superinvention.common.exception.auth.UserNotFoundException
 import org.springframework.core.MethodParameter
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.stereotype.Component
 import org.springframework.web.bind.support.WebDataBinderFactory
 import org.springframework.web.context.request.NativeWebRequest

--- a/src/test/kotlin/com/taskforce/superinvention/app/domain/club/board/ClubBoardServiceTest.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/app/domain/club/board/ClubBoardServiceTest.kt
@@ -58,7 +58,7 @@ class ClubBoardServiceTest: IntegrationTest()  {
         val clubSeq   =  88L
 
         // when
-        val searchInList = sut.getClubBoardList(pageable, searchOpt, clubSeq)
+        val searchInList = sut.getClubBoardList(pageable, ClubBoard.Category.NORMAL, searchOpt, clubSeq)
 
         searchInList.content
 

--- a/src/test/kotlin/com/taskforce/superinvention/config/test/ApiDocumentationTestV2.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/config/test/ApiDocumentationTestV2.kt
@@ -3,12 +3,11 @@ package com.taskforce.superinvention.config.test
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
 import com.taskforce.superinvention.app.domain.user.*
-import com.taskforce.superinvention.common.config.argument.auth.AuthorizeArgumentResolver
+import com.taskforce.superinvention.common.config.argument.resolver.auth.AuthorizeArgumentResolver
 import com.taskforce.superinvention.common.config.security.JwtTokenProvider
 import io.mockk.every
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.test.web.servlet.MockMvc
 
 @AutoConfigureRestDocs


### PR DESCRIPTION
모임 게시판 게시글 카테고리별 검색 api 추가

자잘한 버그 수정으로 

게시글 개별 조회 API 요청 : https://github.com/TASK-FORCE/super-invention/issues/304 와 
모임 게시판 조회 버그      :  https://github.com/TASK-FORCE/super-invention/issues/303 이 있습니다. 