### PR TITLE
모임 삭제기능 개발

### DIFF
--- a/src/course/rest/club/Club.http
+++ b/src/course/rest/club/Club.http
@@ -15,3 +15,10 @@ Authorization: Bearer {{token-sdm}}
 POST {{host}} /clubs/6174/users
 Accept: application/json
 Authorization: Bearer {{token-sdm}}
+
+
+### 모임 삭제
+DELETE {{host}}/clubs/6386
+Content-Type: application/json;charset=UTF-8
+Accept: application/json
+Authorization: Bearer {{token-jun}}

--- a/src/course/rest/club/ClubInfo.http
+++ b/src/course/rest/club/ClubInfo.http
@@ -14,3 +14,9 @@ Authorization: Bearer {{token-sdm}}
 GET {{host}}/clubs/6174
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
+
+### 모임 관심사 그룹으로 검색
+GET {{host}}/clubs/search?regionSeq=501
+Content-Type: application/json;charset=UTF-8
+Accept: application/json
+Authorization: Bearer {{token-jun}}

--- a/src/docs/asciidoc/club/delete.adoc
+++ b/src/docs/asciidoc/club/delete.adoc
@@ -1,0 +1,18 @@
+ifndef::snippets[]
+:sub-snippet: ../../../../build/generated-snippets
+endif::[]
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:sectlinks:
+:site-url: /build/asciidoc/html5/state
+
+Request
+include::{sub-snippet}/club-delete/http-request.adoc[]
+include::{sub-snippet}/club-delete/path-parameters.adoc[]
+
+Response
+include::{sub-snippet}/club-delete/http-response.adoc[]
+include::{sub-snippet}/club-delete/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -106,6 +106,9 @@ include::{root}/club/withdraw.adoc[]
 === [.toc-list-item]`모임원 강퇴`
 include::{root}/club/kick.adoc[]
 
+=== [.toc-list-item]`모임 삭제`
+include::{root}/club/delete.adoc[]
+
 == 모임 게시판
 
 === [.toc-list-item]`모임 게시판 작성`

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/album/ClubAlbumRepository.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/album/ClubAlbumRepository.kt
@@ -26,8 +26,12 @@ class ClubAlbumRepositoryImpl: ClubAlbumRepositoryCustom,
 
         val query = from(clubAlbum)
                 .where(clubAlbum.delete_flag.isFalse, eqSeq(clubAlbum.club.seq, clubSeq))
-                .offset(pageable.offset)
+
+        if (pageable != Pageable.unpaged()) {
+            query.offset(pageable.offset)
                 .limit(pageable.pageSize.toLong())
+        }
+
 
         if(searchOption.title.isNotBlank()) {
             query.where(clubAlbum.title.like("${searchOption.title}%"))

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/album/like/ClubAlbumLikeRepository.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/album/like/ClubAlbumLikeRepository.kt
@@ -12,6 +12,7 @@ interface ClubAlbumLikeRepository: JpaRepository<ClubAlbumLike, Long>, ClubAlbum
 
     fun findByClubAlbumAndClubUser(clubAlbum: ClubAlbum, clubUser: ClubUser): ClubAlbumLike?
     fun findByClubAlbumSeqAndClubUser(clubAlbumSeq: Long, clubUser: ClubUser): ClubAlbumLike?
+    fun findByClubAlbumIn(clubAlbumList: List<ClubAlbum>): List<ClubAlbumLike>
 }
 
 interface ClubAlbumLikeCustom {

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/ClubBoardRepository.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/ClubBoardRepository.kt
@@ -61,8 +61,11 @@ class ClubBoardRepositoryImpl : ClubBoardCustom,
         // 삭제된 글 필터링
         query.where(clubBoard.deleteFlag.isFalse, eqSeq(clubBoard.club, clubSeq))
             .groupBy(clubBoard.seq)
-            .offset(pageable.offset)
-            .limit(pageable.pageSize.toLong())
+
+        if (pageable != Pageable.unpaged()) {
+            query.offset(pageable.offset)
+                .limit(pageable.pageSize.toLong())
+        }
 
         val fetchResult = query.fetchResults()
 

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/comment/ClubBoardCommentRepository.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/comment/ClubBoardCommentRepository.kt
@@ -3,6 +3,7 @@ package com.taskforce.superinvention.app.domain.club.board.comment
 import com.blazebit.persistence.CriteriaBuilderFactory
 import com.blazebit.persistence.querydsl.BlazeJPAQuery
 import com.querydsl.core.types.dsl.BooleanExpression
+import com.taskforce.superinvention.app.domain.club.board.ClubBoard
 import com.taskforce.superinvention.app.domain.club.board.QClubBoard
 import com.taskforce.superinvention.app.domain.user.QUser
 import org.springframework.beans.factory.annotation.Autowired
@@ -14,7 +15,9 @@ import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
 import org.springframework.stereotype.Repository
 
 @Repository
-interface ClubBoardCommentRepository : JpaRepository<ClubBoardComment, Long>, ClubBoardCommentRepositoryCustom
+interface ClubBoardCommentRepository : JpaRepository<ClubBoardComment, Long>, ClubBoardCommentRepositoryCustom {
+    fun findByClubBoardIn(clubBoards: Iterable<ClubBoard>): List<ClubBoardComment>
+}
 
 interface ClubBoardCommentRepositoryCustom {
     fun findRootCommentListWithWriter(pageable: Pageable, clubBoardSeq: Long): Page<ClubBoardComment>

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/like/ClubBoardLikeRepository.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/like/ClubBoardLikeRepository.kt
@@ -5,11 +5,13 @@ import com.taskforce.superinvention.app.domain.club.board.ClubBoard
 import com.taskforce.superinvention.app.domain.club.board.QClubBoard
 import com.taskforce.superinvention.app.domain.club.user.ClubUser
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
 import org.springframework.stereotype.Repository
 
 interface ClubBoardLikeRepository: JpaRepository<ClubBoardLike, Long>, ClubBoardLikeRepositoryCustom {
     fun findByClubBoardAndClubUser(board: ClubBoard, clubUser: ClubUser): ClubBoardLike?
+    fun findByClubBoardIn(clubBoardList: List<ClubBoard>): List<ClubBoardLike>
 }
 
 interface ClubBoardLikeRepositoryCustom {

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/meeting/MeetingApplicationRepository.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/meeting/MeetingApplicationRepository.kt
@@ -16,6 +16,7 @@ import java.util.*
 @Repository
 interface MeetingApplicationRepository : JpaRepository<MeetingApplication, Long>, MeetingApplicationRepositoryCustom {
     fun findByClubUserAndMeeting(clubUser: ClubUser, meeting: Meeting): MeetingApplication?
+    fun findByMeetingIn(meetings: Iterable<Meeting>): List<MeetingApplication>
 }
 
 

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/role/ClubUserRoleRepository.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/role/ClubUserRoleRepository.kt
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository
 @Repository
 interface ClubUserRoleRepository : JpaRepository<ClubUserRole, Long> {
     fun findByClubUser(clubUser: ClubUser): Set<ClubUserRole>
+    fun findByClubUserIn(clubUsers: Iterable<ClubUser>): List<ClubUserRole>
 }

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/controller/club/ClubController.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/controller/club/ClubController.kt
@@ -175,4 +175,12 @@ class ClubController(
         clubService.withdraw(clubUserSeq, actor.seq!!)
         return ResponseDto(ResponseDto.EMPTY)
     }
+
+    @DeleteMapping("/{clubSeq}")
+    fun deleteClub(@AuthUser user: User, @PathVariable clubSeq: Long): ResponseDto<String> {
+        val actor = clubService.getClubUser(clubSeq, user) ?: throw BizException("존재하지 않는 모임원입니다.", HttpStatus.NOT_FOUND)
+        clubService.deleteClub(clubSeq, actor)
+
+        return ResponseDto(ResponseDto.EMPTY)
+    }
 }

--- a/src/test/kotlin/com/taskforce/superinvention/app/domain/club/ClubServiceTest.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/app/domain/club/ClubServiceTest.kt
@@ -1,11 +1,20 @@
 package com.taskforce.superinvention.app.domain.club
 
+import com.taskforce.superinvention.app.domain.club.album.ClubAlbumRepository
+import com.taskforce.superinvention.app.domain.club.album.comment.ClubAlbumCommentRepository
+import com.taskforce.superinvention.app.domain.club.album.like.ClubAlbumLikeRepository
+import com.taskforce.superinvention.app.domain.club.board.ClubBoardRepository
+import com.taskforce.superinvention.app.domain.club.board.comment.ClubBoardCommentRepository
+import com.taskforce.superinvention.app.domain.club.board.img.ClubBoardImgRepository
+import com.taskforce.superinvention.app.domain.club.board.like.ClubBoardLikeRepository
 import com.taskforce.superinvention.app.domain.club.user.ClubUserRepository
 import com.taskforce.superinvention.app.domain.club.user.ClubUserService
 import com.taskforce.superinvention.app.domain.interest.ClubInterestRepository
 import com.taskforce.superinvention.app.domain.interest.interest.Interest
 import com.taskforce.superinvention.app.domain.interest.interest.InterestService
 import com.taskforce.superinvention.app.domain.interest.interestGroup.InterestGroup
+import com.taskforce.superinvention.app.domain.meeting.MeetingApplicationRepository
+import com.taskforce.superinvention.app.domain.meeting.MeetingRepository
 import com.taskforce.superinvention.app.domain.region.ClubRegionRepository
 import com.taskforce.superinvention.app.domain.region.Region
 import com.taskforce.superinvention.app.domain.region.RegionService
@@ -34,6 +43,15 @@ internal class ClubServiceTest {
     lateinit var regionService: RegionService
     lateinit var roleService: RoleService
     lateinit var userRepository: UserRepository
+    lateinit var clubAlbumRepository: ClubAlbumRepository
+    lateinit var clubAlbumCommentRepository: ClubAlbumCommentRepository
+    lateinit var clubBoardRepository: ClubBoardRepository
+    lateinit var clubBoardCommentRepository: ClubBoardCommentRepository
+    lateinit var clubBoardLikeRepository: ClubBoardLikeRepository
+    lateinit var clubBoardImgRepository: ClubBoardImgRepository
+    lateinit var meetingRepository: MeetingRepository
+    lateinit var meetingApplicationRepository: MeetingApplicationRepository
+    lateinit var clubAlbumLikeRepository: ClubAlbumLikeRepository
 
     @BeforeEach
     fun init() {
@@ -47,6 +65,15 @@ internal class ClubServiceTest {
         regionService = mockk()
         roleService = mockk()
         userRepository = mockk()
+        clubAlbumRepository = mockk()
+        clubAlbumCommentRepository = mockk()
+        clubBoardRepository = mockk()
+        clubBoardCommentRepository = mockk()
+        clubBoardLikeRepository = mockk()
+        clubBoardImgRepository = mockk()
+        meetingRepository = mockk()
+        meetingApplicationRepository = mockk()
+        clubAlbumLikeRepository = mockk()
 
         clubService = ClubService(
             clubUserRepository = clubUserRepository,
@@ -58,7 +85,16 @@ internal class ClubServiceTest {
             interestService = interestService,
             regionService = regionService,
             roleService = roleService,
-            userRepository = userRepository
+            userRepository = userRepository,
+            clubAlbumRepository = clubAlbumRepository,
+            clubAlbumCommentRepository = clubAlbumCommentRepository,
+            clubBoardRepository = clubBoardRepository,
+            clubBoardCommentRepository = clubBoardCommentRepository,
+            clubBoardLikeRepository = clubBoardLikeRepository,
+            clubBoardImgRepository = clubBoardImgRepository,
+            meetingRepository = meetingRepository,
+            meetingApplicationRepository = meetingApplicationRepository,
+            clubAlbumLikeRepository = clubAlbumLikeRepository
         )
 
         every { clubRepository.save(any()) }.returns(mockk())

--- a/src/test/kotlin/com/taskforce/superinvention/document/club/ClubInfoDocumentation.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/document/club/ClubInfoDocumentation.kt
@@ -22,11 +22,13 @@ import com.taskforce.superinvention.app.web.dto.club.ClubUserStatusDto
 import com.taskforce.superinvention.app.web.dto.interest.InterestWithPriorityDto
 import com.taskforce.superinvention.app.web.dto.region.RegionWithPriorityDto
 import com.taskforce.superinvention.app.web.dto.region.SimpleRegionDto
+import com.taskforce.superinvention.config.MockitoHelper
 import com.taskforce.superinvention.config.documentation.ApiDocumentUtil.commonResponseField
 import com.taskforce.superinvention.config.documentation.ApiDocumentUtil.getDocumentRequest
 import com.taskforce.superinvention.config.documentation.ApiDocumentUtil.getDocumentResponse
 import com.taskforce.superinvention.config.test.ApiDocumentationTestV2
 import io.mockk.every
+import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
@@ -207,6 +209,35 @@ class ClubInfoDocumentation: ApiDocumentationTestV2() {
                     pathParameters(
                         parameterWithName("clubSeq").description("모임 시퀀스."),
                         parameterWithName("clubUserSeq").description("강퇴 대상 모임원 시퀀스.")
+                    ),
+                    responseFields(
+                        *commonResponseField()
+                    )
+                )
+            )
+    }
+
+    @Test
+    @WithMockUser
+    fun `모임 삭제`() {
+        every { clubService.deleteClub(any(), any()) }.returns(Unit)
+        every { clubService.getClubUser(any(), any()) }.returns(mockk())
+
+        val result = mockMvc.perform(
+            delete("/clubs/{clubSeq}", club.seq)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdXRoIjoiW1VTRVJdIi")
+                .characterEncoding("UTF-8")
+        ).andDo(print())
+
+        result.andExpect(status().isOk)
+            .andDo(
+                document("club-delete",
+                    getDocumentRequest(),
+                    getDocumentResponse(),
+                    pathParameters(
+                        parameterWithName("clubSeq").description("모임 시퀀스")
                     ),
                     responseFields(
                         *commonResponseField()


### PR DESCRIPTION
#187 
해결해야할 문제는 쿼리가 너무 많이 나온다는 문제지만.. 아래 이유로 급한 건은 아니라고 봅니다.
모임 삭제는 자주 일어나는 일이 아니기 때문에, 어느정도의 쿼리량은 우선 감수하고, 추후에 쿼리 리팩토링을 진행하는건 어떨까요?