### PR TITLE
만남 페이징 버그 수정

### DIFF
--- a/src/course/rest/Meeting.http
+++ b/src/course/rest/Meeting.http
@@ -10,6 +10,11 @@ Content-Type: application/json;charset=UTF-8
 Authorization: Bearer {{token-jun}}
 Accept: application/json
 
+### 만남조회3
+GET {{host}}/clubs/6327/meetings?size=1&page=0
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer {{token-jun}}
+Accept: application/json
 
 ### 만남 수정 [준]
 PUT {{host}}/clubs/115/meetings/1 HTTP/1.1

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/meeting/Meeting.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/meeting/Meeting.kt
@@ -22,7 +22,7 @@ class Meeting(
         var regionURL: String?,
         var cost: Int?
 ) : BaseEntity() {
-        @OneToMany(mappedBy = "meeting")
+        @OneToMany(mappedBy = "meeting", fetch = FetchType.EAGER)
         @OrderBy("deleteFlag desc")
         var meetingApplications: List<MeetingApplication> = listOf()
 

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/meeting/MeetingRepository.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/meeting/MeetingRepository.kt
@@ -28,7 +28,6 @@ class MeetingRepositoryImpl : QuerydslRepositorySupport(Meeting::class.java), Me
     override fun getPagedMeetings(clubSeq: Long, pageable: Pageable): Page<Meeting> {
         val query = from(QMeeting.meeting)
                 .join(QMeeting.meeting.club, QClub.club)
-                .leftJoin(QMeeting.meeting.meetingApplications, QMeetingApplication.meetingApplication)
                 .fetchJoin()
                 .where(QClub.club.seq.eq(clubSeq)
                         , QMeeting.meeting.deleteFlag.isFalse
@@ -43,7 +42,7 @@ class MeetingRepositoryImpl : QuerydslRepositorySupport(Meeting::class.java), Me
                 .orderBy(QMeeting.meeting.startTimestamp.desc())
                 .fetchResults()
 
-        return PageImpl(fetchResult.results, pageable, fetchResult.results.size.toLong())
+        return PageImpl(fetchResult.results, pageable, fetchResult.total)
     }
 
     @Transactional


### PR DESCRIPTION
만남에 대한 페이징하는 쿼리에서, 만남 신청을 같이 가져오다보니 정상적으로 페이징이 되고 있지 않았음.

쿼리 두번 날려서 만남, 만남신청을 각각 조회하도록 변경함