### PR TITLE
모임 검색에서 모임원 수가 잘못 표기되는 문제 수정

### DIFF
--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/ClubService.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/ClubService.kt
@@ -209,6 +209,7 @@ class ClubService(
     @Transactional(readOnly = true)
     fun search(request: ClubSearchRequestDto, pageable: Pageable): PageDto<ClubWithRegionInterestDto> {
         // 하위 지역까지 모두 입력하자
+
         val regionSeqList = arrayListOf<Long>()
         if (request.regionSeq != null){
             regionSeqList.add(request.regionSeq!!)
@@ -219,7 +220,7 @@ class ClubService(
         val result = clubRepository.search(request.text, regionSeqList, request.interestSeq, request.interestGroupSeq, pageable)
         val mappingContents = result.content.map { e ->  ClubWithRegionInterestDto(
                 club = e,
-                userCount = e.clubUser.size.toLong()
+                userCount = e.userCount ?: 0
         )}.toList()
 
         val resultPage = PageImpl(mappingContents, result.pageable, result.totalElements)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/50672087/113334764-0a5d6080-935f-11eb-88b8-ac4de3dff44a.png)

실제로 2~3명인 모임임에도 불구하고 모든 검색 모임들이 1명으로 나오는 문제 해결 