### PR TITLE
게시글 좋아요 테스트 작성

### DIFF
--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/like/ClubBoardLikeService.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/like/ClubBoardLikeService.kt
@@ -2,8 +2,10 @@ package com.taskforce.superinvention.app.domain.club.board.like
 
 import com.taskforce.superinvention.app.domain.club.board.ClubBoardRepository
 import com.taskforce.superinvention.app.domain.club.user.ClubUserRepository
+import com.taskforce.superinvention.app.domain.role.RoleService
 import com.taskforce.superinvention.app.domain.user.User
 import com.taskforce.superinvention.app.web.dto.club.board.like.ClubBoardLikeDto
+import com.taskforce.superinvention.common.exception.auth.InsufficientAuthException
 import com.taskforce.superinvention.common.exception.club.ClubNotFoundException
 import com.taskforce.superinvention.common.exception.club.UserIsNotClubMemberException
 import com.taskforce.superinvention.common.exception.club.board.ClubBoardNotFoundException
@@ -15,13 +17,18 @@ import org.springframework.transaction.annotation.Transactional
 class ClubBoardLikeService(
     private val clubBoardLikeRepository: ClubBoardLikeRepository,
     private val clubBoardRepository    : ClubBoardRepository,
-    private val clubUserRepository     : ClubUserRepository
+    private val clubUserRepository     : ClubUserRepository,
+    private val roleService: RoleService
 ) {
 
     @Transactional
     fun registerClubBoardLike(user: User, clubSeq: Long, clubBoardSeq: Long): ClubBoardLikeDto {
         val clubUser  = clubUserRepository.findByClubSeqAndUser(clubSeq, user)
             ?: throw UserIsNotClubMemberException()
+
+        if (!roleService.hasClubMemberAuth(clubUser)) {
+            throw InsufficientAuthException("탈퇴한 유저는 좋아요를 할 수 없습니다.")
+        }
 
         val clubBoard = clubBoardRepository.findByIdOrNull(clubBoardSeq)
             ?: throw ClubBoardNotFoundException()
@@ -45,8 +52,12 @@ class ClubBoardLikeService(
         val clubUser   = clubUserRepository.findByClubSeqAndUser(clubSeq, user)
             ?: throw UserIsNotClubMemberException()
 
+        if (!roleService.hasClubMemberAuth(clubUser)) {
+            throw InsufficientAuthException("탈퇴한 유저는 좋아요 취소를 할 수 없습니다.")
+        }
+
         val clubBoard  = clubBoardRepository.findByIdOrNull(clubBoardSeq)
-            ?: throw ClubNotFoundException()
+            ?: throw ClubBoardNotFoundException()
 
         clubBoardLikeRepository.findByClubBoardAndClubUser(clubBoard, clubUser)
                 ?.let(clubBoardLikeRepository::delete)


### PR DESCRIPTION
#353 
# 테스트 리스트

탈퇴한 모임원이 좋아요 취소를 누를 때 실패해야 한다()
최초로 모임원이 좋아요를 누를 때 성공해야 한다()
가입한적 없는 유저가 좋아요를 누를 때 실패해야 한다()
삭제된 게시글에 좋아요 취소를 누를 때 실패해야 한다()
좋아요를 누르지 않은 모임원이 좋아요 취소를 누를 때 delete를 호출하지 않아야 한고 무시해야 한다()
탈퇴한 모임원이 좋아요를 누를 때 실패해야 한다()
강퇴당한 모임원이 좋아요를 누를 때 실패해야 한다()
가입한적 없는 유저가 좋아요 취소를 누를 때 실패해야 한다()
삭제된 게시글에 좋아요를 누를 때 실패해야 한다()
좋아요를 한 모임원이 좋아요 취소를 누를 때 성공해야 한다()
이미 좋아요를 누른 상태에서 좋아요를 또 눌렀을 경우 저장하지 않고 무시한다()
강퇴당한 모임원이 좋아요 취소를 누를 때 실패해야 한다()

권한관련된 테스트가 깨져서, 빌드는 실패할거같네요. 수정되면 테스트 돌려보고 머지하면 될거같습니다.