### PR TITLE
게시글 댓글 테스트 작성

### DIFF
--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/comment/ClubBoardCommentService.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/comment/ClubBoardCommentService.kt
@@ -8,6 +8,7 @@ import com.taskforce.superinvention.app.web.dto.club.board.comment.ClubBoardComm
 import com.taskforce.superinvention.app.web.dto.club.board.comment.ClubBoardCommentRegisterDto
 import com.taskforce.superinvention.app.web.dto.common.PageDto
 import com.taskforce.superinvention.common.exception.ResourceNotFoundException
+import com.taskforce.superinvention.common.exception.auth.InsufficientAuthException
 import com.taskforce.superinvention.common.exception.auth.OnlyWriterCanAccessException
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
@@ -70,6 +71,11 @@ class ClubBoardCommentService(
         val clubUser  = clubUserService.getValidClubUser(clubSeq, user)
         val clubBoard = clubBoardService.getValidClubBoardBySeq(clubBoardSeq)
 
+        if (!roleService.hasClubMemberAuth(clubUser)) {
+            throw InsufficientAuthException("탈퇴한 유저는 댓글을 등록하실 수 없습니다.")
+        }
+
+
         var parentComment: ClubBoardComment?= null
         var depth = 1L
 
@@ -100,6 +106,10 @@ class ClubBoardCommentService(
     ) {
 
         val clubUser = clubUserService.getValidClubUser(clubSeq, user)
+        if (!roleService.hasClubMemberAuth(clubUser)) {
+            throw InsufficientAuthException("탈퇴한 유저는 댓글을 수정하실 수 없습니다.")
+        }
+
         val comment  = getValidCommentBySeq(clubBoardCommentSeq)
 
         if(comment.clubUser != clubUser) {

--- a/src/test/kotlin/com/taskforce/superinvention/app/domain/club/board/comment/ClubBoardCommentServiceTest.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/app/domain/club/board/comment/ClubBoardCommentServiceTest.kt
@@ -9,6 +9,7 @@ import com.taskforce.superinvention.app.domain.role.RoleService
 import com.taskforce.superinvention.app.domain.user.User
 import com.taskforce.superinvention.app.web.dto.club.board.comment.ClubBoardCommentRegisterDto
 import com.taskforce.superinvention.common.exception.BizException
+import com.taskforce.superinvention.common.exception.auth.InsufficientAuthException
 import com.taskforce.superinvention.common.exception.auth.OnlyWriterCanAccessException
 import io.mockk.every
 import io.mockk.mockk
@@ -86,6 +87,7 @@ internal class ClubBoardCommentServiceTest {
         every { clubUserService.getValidClubUser(club.seq!!, user) }.returns(clubUser)
         every { clubBoardService.getValidClubBoardBySeq(clubBoard.seq!!) }.returns(clubBoard)
         every { clubBoardCommentRepository.save(any()) }.returnsArgument(0)
+        every { roleService.hasClubMemberAuth(clubUser) }.returns(true)
 
 
         // when
@@ -110,7 +112,7 @@ internal class ClubBoardCommentServiceTest {
 
 
         // when & then
-        assertThrows<BizException> {
+        assertThrows<InsufficientAuthException> {
             clubBoardCommentService.registerComment(
                 club.seq!!,
                 clubBoard.seq!!,
@@ -126,6 +128,7 @@ internal class ClubBoardCommentServiceTest {
         // given
         every { clubUserService.getValidClubUser(club.seq!!, user) }.returns(clubUser)
         every { clubBoardCommentService.getValidCommentBySeq(any()) }.returns(clubBoardComment)
+        every { roleService.hasClubMemberAuth(clubUser) }.returns(true)
 
         // when
         clubBoardCommentService.editComment(
@@ -147,7 +150,7 @@ internal class ClubBoardCommentServiceTest {
         every { roleService.hasClubMemberAuth(clubUser) }.returns(false)
 
         // when & then
-        assertThrows<BizException> {
+        assertThrows<InsufficientAuthException> {
             clubBoardCommentService.editComment(
                 club.seq!!,
                 clubBoard.seq!!,
@@ -164,6 +167,7 @@ internal class ClubBoardCommentServiceTest {
         clubBoardComment.clubUser = ClubUser(mockk(), mockk())
         every { clubUserService.getValidClubUser(club.seq!!, user) }.returns(clubUser)
         every { clubBoardCommentService.getValidCommentBySeq(any()) }.returns(clubBoardComment)
+        every { roleService.hasClubMemberAuth(clubUser) }.returns(true)
 
         // when & then
         assertThrows<OnlyWriterCanAccessException> {


### PR DESCRIPTION
#353 
@SightStudio 
깨지는 테스트 확인 부탁드립니다 :)

# 테스트코드 리스트
모임원이 게시글 댓글 등록을 요청하면 성공해야 한다()
댓글 작성자가 아닌 모임원이 댓글을 삭제할 경우 실패해야 한다()
모임원 아닌 유저가 게시글 댓글 수정을 요청하면 실패해야 한다()
댓글을 작성한 모임원이 게시글 댓글 수정을 요청하면 성공해야 한다()
작성자가 아닌 유저가 게시글 댓글 수정을 요청하면 실패해야 한다()
댓글 작성자가 아닌 매니저가 댓글을 삭제할 경우 성공해야 한다()
댓글 작성자가 댓글 삭제를 삭제할 경우 성공해야 한다()
모임원 아닌 유저가 게시글 댓글 등록을 요청하면 실패해야 한다()