### PR TITLE
JPA Build Configuration for Lazy loading

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,12 @@ plugins {
     kotlin("plugin.noarg")    version "1.4.21"
 }
 
+allOpen {
+    annotation("javax.persistence.Entity")
+    annotation("javax.persistence.Embeddable")
+    annotation("javax.persistence.MappedSuperclass")
+}
+
 group = "com.taskforce"
 version = "SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
#415 
https://spring.io/guides/tutorials/spring-boot-kotlin/
코틀린 JPA사용시 해당 옵션을 사용하지 않으면 LAZY-LOADING이 잘 적용되지 않을 수 있어, 픽스합니다.